### PR TITLE
Add asciidoc grammar to defaults

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -5,6 +5,7 @@ module.exports =
     grammars:
       type: 'array'
       default: [
+        'source.asciidoc'
         'source.gfm'
         'text.git-commit'
         'text.plain'


### PR DESCRIPTION
Please, consider adding asciidoc grammar to defaults. As well as with Markdown, vast majority of AsciiDoc users expect spell-checking to be enabled by default. Here is a related issue for `language-asciidoc` package asciidoctor/atom-language-asciidoc#5.