### PR TITLE
Remove Correct Spelling from mini editor context menu

### DIFF
--- a/menus/spell-check.cson
+++ b/menus/spell-check.cson
@@ -1,4 +1,4 @@
 'context-menu':
-  'atom-text-editor': [
+  'atom-text-editor:not([mini])': [
     {label: 'Correct Spelling', command: 'spell-check:correct-misspelling'}
   ]


### PR DESCRIPTION
Part of atom/settings-view#354

This removes Correct Spelling from mini editors' context menus - if this is a bit too far-reaching I can limit it to mini editors in panes without file paths, but the current behavior is confusing since it looks for a language grammar.