### PR TITLE
Stronger underline

### DIFF
--- a/styles/spell-check.atom-text-editor.less
+++ b/styles/spell-check.atom-text-editor.less
@@ -1,3 +1,3 @@
 .spell-check-misspelling .region {
-  border-bottom: 1px dashed rgba(250, 128, 114, .5);
+  border-bottom: 2px dotted hsla(0, 100%, 60%, 0.75);
 }


### PR DESCRIPTION
This PR makes the border stronger and easier to spot.

Before:

![screen shot 2015-09-29 at 2 07 12 pm](https://cloud.githubusercontent.com/assets/378023/10155710/760f5ab0-66b3-11e5-9453-3fa1be7066da.png)

After:

![screen shot 2015-09-29 at 2 06 52 pm](https://cloud.githubusercontent.com/assets/378023/10155714/7dc677d4-66b3-11e5-847b-c5832f477c91.png)

- 2px width
- `dotted` instead of dashed, so that it doesn't look strange when narrow.
- less transparent red

Fixes #86