### PR TITLE
Improve performance with long documents

### DIFF
--- a/lib/spell-check-handler.coffee
+++ b/lib/spell-check-handler.coffee
@@ -2,8 +2,9 @@ SpellChecker = require 'spellchecker'
 
 wordRegex = /(?:^|[\s\[\]"'])([a-zA-Z]+([a-zA-Z']+[a-zA-Z])?)(?=[\s\.\[\]:,"']|$)/g
 
-module.exports = ({id, text}) ->
-  row = 0
+module.exports = ({id, range, text}) ->
+  row = range.start.row
+  first = true
   misspellings = []
   for line in text.split('\n')
     while matches = wordRegex.exec(line)
@@ -11,8 +12,10 @@ module.exports = ({id, text}) ->
       continue if word in ['GitHub', 'github']
       continue unless SpellChecker.isMisspelled(word)
 
-      startColumn = matches.index + matches[0].length - word.length
+      columnOffset = if first then range.start.column else 0
+      first = false
+      startColumn = columnOffset + matches.index + matches[0].length - word.length
       endColumn = startColumn + word.length
       misspellings.push([[row, startColumn], [row, endColumn]])
     row++
-  {id, misspellings}
+  {id, range, misspellings}

--- a/lib/spell-check-task.coffee
+++ b/lib/spell-check-task.coffee
@@ -17,12 +17,12 @@ class SpellCheckTask
       @constructor.task?.terminate()
       @constructor.task = null
 
-  start: (text) ->
+  start: (range, text) ->
     @constructor.task ?= new Task(require.resolve('./spell-check-handler'))
-    @constructor.task?.start {@id, text}, @constructor.dispatchMisspellings
+    @constructor.task?.start {@id, range, text}, @constructor.dispatchMisspellings
 
   onDidSpellCheck: (callback) ->
     @constructor.callbacksById[@id] = callback
 
-  @dispatchMisspellings: ({id, misspellings}) =>
-    @callbacksById[id]?(misspellings)
+  @dispatchMisspellings: ({id, range, misspellings}) =>
+    @callbacksById[id]?(range, misspellings)

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -1,5 +1,5 @@
 _ = require 'underscore-plus'
-{CompositeDisposable} = require 'atom'
+{CompositeDisposable, Range} = require 'atom'
 MisspellingView = require './misspelling-view'
 SpellCheckTask = require './spell-check-task'
 
@@ -13,8 +13,8 @@ class SpellCheckView
     @views = []
     @task = new SpellCheckTask()
 
-    @task.onDidSpellCheck (misspellings) =>
-      @destroyViews()
+    @task.onDidSpellCheck (range, misspellings) =>
+      @destroyViews(range)
       @addViews(misspellings) if @buffer?
 
     @disposables.add @editor.onDidChangePath =>
@@ -42,7 +42,8 @@ class SpellCheckView
     @destroyViews()
 
     if @buffer?
-      @bufferDisposable.dispose()
+      @bufferOnDidChangeDisposable.dispose()
+      @bufferOnDidStopChangingDisposable.dispose()
       @buffer = null
 
   subscribeToBuffer: ->
@@ -50,25 +51,116 @@ class SpellCheckView
 
     if @spellCheckCurrentGrammar()
       @buffer = @editor.getBuffer()
-      @bufferDisposable = @buffer.onDidStopChanging => @updateMisspellings()
+      @ranges = []
+      @bufferOnDidChangeDisposable = @buffer.onDidChange (e) =>
+        @updateChanges(e)
+      @bufferOnDidStopChangingDisposable = @buffer.onDidStopChanging =>
+        @updateMisspellings()
       @updateMisspellings()
 
   spellCheckCurrentGrammar: ->
     grammar = @editor.getGrammar().scopeName
     _.contains(atom.config.get('spell-check.grammars'), grammar)
 
-  destroyViews: ->
+  # kill all the MisspellingViews which intersect with range
+  destroyViews: (range) ->
+    if not range? and @buffer?
+      range = @buffer.getRange()
+    newViews = []
     while view = @views.shift()
-      view.destroy()
+      if view.marker.getBufferRange().intersectsWith(range) or not @buffer?
+        view.destroy()
+      else
+        newViews.push(view)
+    @views = newViews
 
   addViews: (misspellings) ->
     for misspelling in misspellings
       view = new MisspellingView(misspelling, @editor)
       @views.push(view)
 
+  # accumulate changes
+  updateChanges: (event) ->
+    added = false
+    for range, i in @ranges
+      if range.intersectsWith(event.newRange)
+        @ranges[i] = range.union(event.newRange)
+        added = true
+    if not added
+      @ranges.push(event.newRange)
+
+  # expand range to include nearest word boundaries
+  expandRange: (range) ->
+    start = @getBeginningOfWordPosition(range.start)
+    end = @getEndOfWordPosition(range.end)
+    new Range(start, end)
+
   updateMisspellings: ->
-    # Task::start can throw errors atom/atom#3326
-    try
-      @task.start(@buffer.getText())
-    catch error
-      console.warn('Error starting spell check task', error.stack ? error)
+    # this function is also called on load, when no changes have been made
+    # in which case we spell-check the whole document.
+    if @ranges.length == 0
+      range = @buffer.getRange()
+      @ranges.push(range)
+    # dispatch a new task for each range
+    for range in @ranges
+      range = @expandRange(range)
+      text = @buffer.getTextInRange(range)
+      console.log(range, text)
+      try
+        @task.start(range, text)
+      catch error
+        # Task::start can throw errors atom/atom#3326
+        console.warn('Error starting spell check task', error.stack ? error)
+    @ranges = []
+
+  # Utility functions
+
+  # get the beginning of the word at this point. Copied from the Cursor library.
+  getBeginningOfWordPosition: (point) ->
+    allowPrevious = false
+    currentBufferPosition = point
+    previousNonBlankRow = @editor.buffer.previousNonBlankRow(currentBufferPosition.row) ? 0
+    scanRange = [[previousNonBlankRow, 0], currentBufferPosition]
+
+    beginningOfWordPosition = null
+    @editor.backwardsScanInBufferRange (@wordRegExp(point)), scanRange, ({range, stop}) ->
+      if range.end.isGreaterThanOrEqual(currentBufferPosition) or allowPrevious
+        beginningOfWordPosition = range.start
+      if not beginningOfWordPosition?.isEqual(currentBufferPosition)
+        stop()
+
+    if beginningOfWordPosition?
+      beginningOfWordPosition
+    else if allowPrevious
+      new Point(0, 0)
+    else
+      currentBufferPosition
+
+  # get the end of the word at this point. Copied from the Cursor library.
+  getEndOfWordPosition: (point) ->
+    allowNext = false
+    currentBufferPosition = point
+    scanRange = [currentBufferPosition, @editor.getEofBufferPosition()]
+
+    endOfWordPosition = null
+    @editor.scanInBufferRange (@wordRegExp(point)), scanRange, ({range, stop}) ->
+      if allowNext
+        if range.end.isGreaterThan(currentBufferPosition)
+          endOfWordPosition = range.end
+          stop()
+      else
+        if range.start.isLessThanOrEqual(currentBufferPosition)
+          endOfWordPosition = range.end
+        stop()
+
+    endOfWordPosition ? currentBufferPosition
+
+  # The correct regular expression to match words at the current scope. Copied from cursor library.
+  wordRegExp: (point) ->
+    includeNonWordCharacters = true
+    nonWordCharacters = atom.config.get('editor.nonWordCharacters', scope: @editor.scopeDescriptorForBufferPosition(point))
+    segments = ["^[\t ]*$"]
+    segments.push("[^\\s#{_.escapeRegExp(nonWordCharacters)}]+")
+    if includeNonWordCharacters
+      segments.push("[#{_.escapeRegExp(nonWordCharacters)}]+")
+    new RegExp(segments.join("|"), "g")


### PR DESCRIPTION
This fix ensures that the whole document is not spell checked, only the
changes which were made since the last spell check.

Closes #37 and #53
