### PR TITLE
Defer jQuery initialization

### DIFF
--- a/lib/misspelling-view.coffee
+++ b/lib/misspelling-view.coffee
@@ -1,4 +1,4 @@
-CorrectionsView = require './corrections-view'
+CorrectionsView = null
 
 module.exports =
 class MisspellingView
@@ -6,6 +6,7 @@ class MisspellingView
     @createMarker(bufferRange)
     @correctMispellingCommand = atom.commands.add atom.views.getView(@editor), 'spell-check:correct-misspelling', =>
       if @containsCursor()
+        CorrectionsView ?= require './corrections-view'
         @correctionsView?.destroy()
         @correctionsView = new CorrectionsView(@editor, @getCorrections(), @marker)
 


### PR DESCRIPTION
Previously I made some attempts to migrate our legacy jQuery code to vanilla HTML. Although honorable, that requires a bit of time and has the risk of introducing regressions.

This, on the other hand, is a quick win that, in conjunction with https://github.com/atom/image-view/pull/47, allows us to make startup `50ms` faster by deferring jQuery initialization until the last possible moment (i.e. not during startup).