### PR TITLE
updates spellchecker to use system language

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Highlights misspelled words and shows possible corrections.",
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
-    "spellchecker": "3.2.0",
+    "spellchecker": "3.2.3",
     "underscore-plus": "^1"
   },
   "repository": "https://github.com/atom/spell-check",


### PR DESCRIPTION
As of atom/node-spellchecker#33 (v3.2.3), the default language used is that of the `LANG` environment variable. This is an (non-closing) improvement for those subscribed to #21.