### PR TITLE
Add scope whitelist support

### DIFF
--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -83,13 +83,20 @@ class SpellCheckView
     @initializeMarkerLayer()
 
   addMarkers: (misspellings) ->
+    scope_whitelist = atom.config.get('spell-check.scopes')
     for misspelling in misspellings
-      @markerLayer.markRange(misspelling,
-        invalidate: 'touch',
-        replicate: 'false',
-        persistent: false,
-        maintainHistory: false,
-      )
+      # Find scopes for the text given at the starting position of the misspelling
+      scopes_for_misspelling = @editor.scopeDescriptorForBufferPosition(misspelling[0]).getScopesArray()
+      # Mark the misspelling if there is no whitelist or there are whole-word matches between
+      # the scopes and the whitelist
+      if scope_whitelist.length is 0 or _.intersection(scopes_for_misspelling, scope_whitelist).length > 0
+        @markerLayer.markRange(misspelling,
+          invalidate: 'touch',
+          replicate: 'false',
+          persistent: false,
+          maintainHistory: false,
+        )
+    return
 
   updateMisspellings: ->
     # Task::start can throw errors atom/atom#3326

--- a/package.json
+++ b/package.json
@@ -23,7 +23,12 @@
         "text.plain",
         "text.plain.null-grammar"
       ],
-      "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package-) for more information on finding the correct scope for a specific language."
+      "description": "List of top-level scopes for languages which will be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package-) for more information on finding the correct scope for a specific language."
+    },
+    "scopes": {
+      "type": "array",
+      "default": [],
+      "description": "List of specific scopes you want to be included when checking for misspellings. These scopes must be contained within the activated top-level scopes listed in the 'Grammars' configuration section. _When defined, spell checking will be ignored for any scope not listed._"
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Basically, just before doing the marking of the spelling errors, check for a new scopes configuration array. If that array has scopes, this checks that one of those scopes is in the scope list for the current spelling error.

My example screenshots show enabling spell check with PHP files, but whitelisting only single and multiline comments for spell checking. _Note that there are misspellings in the example code, but they are not marked, as intended._

[Example Editor Screenshot](https://www.dropbox.com/s/ynif1m2dk97o1pc/Screenshot%202016-02-23%2010.29.45.png?dl=0)
[New Configuration Screenshot](https://www.dropbox.com/s/kz974x8f6se5npl/Screenshot%202016-02-23%2010.10.04.png?dl=0)

Also, this would help solve https://github.com/atom/spell-check/issues/19
