### PR TITLE
Add scope blacklist support

### DIFF
--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -83,7 +83,11 @@ class SpellCheckView
     @initializeMarkerLayer()
 
   addMarkers: (misspellings) ->
+    scope_blacklist = atom.config.get('spell-check.scopeBlacklist')
     for misspelling in misspellings
+      scopes_for_misspelling = @editor.scopeDescriptorForBufferPosition(misspelling[0]).getScopesArray()
+      if _.intersection(scopes_for_misspelling, scope_blacklist).length > 0
+        return
       @markerLayer.markRange(misspelling,
         invalidate: 'touch',
         replicate: 'false',

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
         "text.plain.null-grammar"
       ],
       "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package-) for more information on finding the correct scope for a specific language."
+    },
+    "scopeBlacklist": {
+      "type": "array",
+      "default": [
+        "markup.code.json.gfm"
+      ]
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Inspired by #116 this adds scope blacklisting support. For example include the `source.gfm` grammar, but disable spellchecking for `markup.code.json.gfm`. So general Markdown would be spell checked, but embedded JSON code snippets would be excluded 🎉.