### PR TITLE
Add marker layers on TextEditor and stop using marker custom properties

### DIFF
--- a/lib/corrections-view.coffee
+++ b/lib/corrections-view.coffee
@@ -24,7 +24,7 @@ class CorrectionsView extends SelectListView
     @cancel()
     return unless correction
     @editor.transact =>
-      @editor.setSelectedBufferRange(@marker.getRange())
+      @editor.setSelectedBufferRange(@marker.getBufferRange())
       @editor.insertText(correction)
 
   cancelled: ->

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -16,7 +16,7 @@ class SpellCheckView
     @initializeMarkerLayer()
 
     @correctMisspellingCommand = atom.commands.add atom.views.getView(@editor), 'spell-check:correct-misspelling', =>
-      if marker = @markerLayer.findMarkers({containsPoint: @editor.getCursorBufferPosition()})[0]
+      if marker = @markerLayer.findMarkers({containsBufferPosition: @editor.getCursorBufferPosition()})[0]
         CorrectionsView ?= require './corrections-view'
         @correctionsView?.destroy()
         @correctionsView = new CorrectionsView(@editor, @getCorrections(marker), marker)
@@ -42,7 +42,7 @@ class SpellCheckView
     @disposables.add @editor.onDidDestroy(@destroy.bind(this))
 
   initializeMarkerLayer: ->
-    @markerLayer = @editor.getBuffer().addMarkerLayer()
+    @markerLayer = @editor.addMarkerLayer({maintainHistory: false})
     @markerLayerDecoration = @editor.decorateMarkerLayer(@markerLayer, {
       type: 'highlight',
       class: 'spell-check-misspelling',
@@ -84,12 +84,7 @@ class SpellCheckView
 
   addMarkers: (misspellings) ->
     for misspelling in misspellings
-      @markerLayer.markRange(misspelling,
-        invalidate: 'touch',
-        replicate: 'false',
-        persistent: false,
-        maintainHistory: false,
-      )
+      @markerLayer.markBufferRange(misspelling, {invalidate: 'touch'})
 
   updateMisspellings: ->
     # Task::start can throw errors atom/atom#3326
@@ -100,5 +95,5 @@ class SpellCheckView
 
   getCorrections: (marker) ->
     SpellChecker ?= require 'spellchecker'
-    misspelling = @editor.getTextInBufferRange(marker.getRange())
+    misspelling = @editor.getTextInBufferRange(marker.getBufferRange())
     corrections = SpellChecker.getCorrectionsForMisspelling(misspelling)

--- a/spec/spell-check-spec.coffee
+++ b/spec/spell-check-spec.coffee
@@ -2,7 +2,7 @@ describe "Spell check", ->
   [workspaceElement, editor, editorElement, spellCheckModule] = []
 
   textForMarker = (marker) ->
-    editor.getTextInBufferRange(marker.getRange())
+    editor.getTextInBufferRange(marker.getBufferRange())
 
   getMisspellingMarkers = ->
     spellCheckModule.misspellingMarkersForEditor(editor)


### PR DESCRIPTION
We were using a deprecated `replicate` custom property. Moreover, this marks the entire layer as `{maintainHistory: false}`, rather than specifying the same option on every single marker.

/cc: @nathansobo 