### PR TITLE
Prevent toggling spell-check when there is no active text editor

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -27,6 +27,8 @@ module.exports =
 
   # Internal: Toggles the spell-check activation state.
   toggle: ->
+    if not atom.workspace.getActiveTextEditor()
+      return
     editorId = atom.workspace.getActiveTextEditor().id
 
     if spellCheckViews[editorId]['active']


### PR DESCRIPTION
Fixes #130