### PR TITLE
Add text.md to grammars list

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "source.asciidoc",
         "source.gfm",
         "text.git-commit",
+        "text.md",
         "text.plain",
         "text.plain.null-grammar"
       ],


### PR DESCRIPTION
Enable spelling for the language-markdown language, which replaces language-gfm.
