### PR TITLE
Don't destroy editors when deactivating package

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -75,8 +75,8 @@ module.exports =
 
     # Clear out the known views.
     for editorId of spellCheckViews
-      view = spellCheckViews[editorId]
-      view['editor'].destroy()
+      {view} = spellCheckViews[editorId]
+      view.destroy()
     spellCheckViews = {}
 
     # While we have WeakMap.clear, it isn't a function available in ES6. So, we


### PR DESCRIPTION
Previously, upon package deactivation, we were destroying all the editors where spell-check was enabled. This pull-request changes it so that we destroy only the view which, in turn, will clear all the created markers and decorations.

@dmoonfire: can you confirm this was the intended behavior?