### PR TITLE
Added `/usr/share/myspell` as a search path

### DIFF
--- a/lib/system-checker.coffee
+++ b/lib/system-checker.coffee
@@ -59,6 +59,8 @@ class SystemChecker
     if /linux/.test process.platform
       if @spellchecker.setDictionary @locale, "/usr/share/hunspell"
         return
+      if @spellchecker.setDictionary @locale, "/usr/share/myspell"
+        return
       if @spellchecker.setDictionary @locale, "/usr/share/myspell/dicts"
         return
 


### PR DESCRIPTION
For Fedora-based distributions, the path for dictionaries is `/usr/share/myspell`. (Closes #164)
