### PR TITLE
Do not spell check massive files

### DIFF
--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -86,6 +86,8 @@ class SpellCheckView
       @markerLayer.markBufferRange(misspelling, {invalidate: 'touch'})
 
   updateMisspellings: ->
+    return @destroyMarkers() if @editor.largeFileMode
+
     # Task::start can throw errors atom/atom#3326
     try
       @taskWrapper.start @editor.buffer


### PR DESCRIPTION
This makes Atom a lot more usable in multi-mega-byte files

I couldn't find an existing spec testing `spell-check-manager.coffee` so no idea where to add the spec :)
