### PR TITLE
Display corrections in context menu for #54

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -48,6 +48,7 @@ module.exports =
     @commandSubscription = atom.commands.add 'atom-workspace',
         'spell-check:toggle': => @toggle()
     @viewsByEditor = new WeakMap
+    @contextMenuEntries = []
     @disposable = atom.workspace.observeTextEditors (editor) =>
       SpellCheckView ?= require './spell-check-view'
 
@@ -55,7 +56,12 @@ module.exports =
       # background checking and a cached view of the in-process manager for
       # getting corrections. We used a function to a function because scope
       # wasn't working properly.
-      spellCheckView = new SpellCheckView(editor, @task, => @getInstance @globalArgs)
+      # Each view also needs the list of added context menu entries so that
+      # they can dispose old corrections which were not created by the current
+      # active editor. A reference to this entire module is passed right now
+      # because a direct reference to @contextMenuEntries wasn't updating
+      # properly between different SpellCheckView's.
+      spellCheckView = new SpellCheckView(editor, @task, this, => @getInstance @globalArgs)
 
       # save the {editor} into a map
       editorId = editor.id

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -121,14 +121,12 @@ class SpellCheckView
 
     # Check to see if the selected word is incorrect.
     if marker = @markerLayer.findMarkers({containsBufferPosition: currentBufferPosition})[0]
-      separatorMenuItem = atom.contextMenu.add {'atom-text-editor': [{type: 'separator'}]}
-      @spellCheckModule.contextMenuEntries.push {menuItem: separatorMenuItem}
-
       corrections = @getCorrections(marker)
-      if corrections.length is 0
-        noCorrectionsMenuItem = atom.contextMenu.add {'atom-text-editor': [{label: 'No corrections '}]}
-        @spellCheckModule.contextMenuEntries.push {menuItem: noCorrectionsMenuItem}
-      else
+      if corrections.length > 0
+        @spellCheckModule.contextMenuEntries.push({
+          menuItem: atom.contextMenu.add({'atom-text-editor': [{type: 'separator'}]})
+        })
+
         for correction in @getCorrections(marker)
           contextMenuEntry = {}
           # Register new command for correction.
@@ -139,12 +137,9 @@ class SpellCheckView
                 @clearContextMenuEntries()
 
           # Add new menu item for correction.
-          contextMenuEntry.menuItem = atom.contextMenu.add {
-            'atom-text-editor': [{
-              label: correction.label,
-              command: 'spell-check:correct-misspelling-' + correction.index
-            }]
-          }
+          contextMenuEntry.menuItem = atom.contextMenu.add({
+            'atom-text-editor': [{label: correction.label, command: 'spell-check:correct-misspelling-' + correction.index}]
+          })
           @spellCheckModule.contextMenuEntries.push contextMenuEntry
 
   makeCorrection: (correction, marker) =>
@@ -169,11 +164,10 @@ class SpellCheckView
 
       # Update the buffer to handle the corrections.
       @updateMisspellings.bind(this)()
-  
+
   clearContextMenuEntries: ->
     for entry in @spellCheckModule.contextMenuEntries
       entry.command?.dispose()
       entry.menuItem?.dispose()
 
     @spellCheckModule.contextMenuEntries = []
-

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -127,20 +127,26 @@ class SpellCheckView
           menuItem: atom.contextMenu.add({'atom-text-editor': [{type: 'separator'}]})
         })
 
+        correctionIndex = 0
         for correction in corrections
           contextMenuEntry = {}
           # Register new command for correction.
+          commandName = 'spell-check:correct-misspelling-' + correctionIndex
           contextMenuEntry.command = do (correction, contextMenuEntry) =>
-            atom.commands.add atom.views.getView(@editor),
-              'spell-check:correct-misspelling-' + correction.index, =>
-                @makeCorrection(correction, marker)
-                @clearContextMenuEntries()
+            atom.commands.add atom.views.getView(@editor), commandName, =>
+              @makeCorrection(correction, marker)
+              @clearContextMenuEntries()
 
           # Add new menu item for correction.
           contextMenuEntry.menuItem = atom.contextMenu.add({
-            'atom-text-editor': [{label: correction.label, command: 'spell-check:correct-misspelling-' + correction.index}]
+            'atom-text-editor': [{label: correction.label, command: commandName}]
           })
           @spellCheckModule.contextMenuEntries.push contextMenuEntry
+          correctionIndex++
+
+        @spellCheckModule.contextMenuEntries.push({
+          menuItem: atom.contextMenu.add({'atom-text-editor': [{type: 'separator'}]})
+        })
 
   makeCorrection: (correction, marker) =>
     if correction.isSuggestion

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -127,7 +127,7 @@ class SpellCheckView
           menuItem: atom.contextMenu.add({'atom-text-editor': [{type: 'separator'}]})
         })
 
-        for correction in @getCorrections(marker)
+        for correction in corrections
           contextMenuEntry = {}
           # Register new command for correction.
           contextMenuEntry.command = do (correction, contextMenuEntry) =>

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -114,7 +114,8 @@ class SpellCheckView
   addContextMenuEntries: (mouseEvent) =>
     @clearContextMenuEntries()
     # Get buffer position of the right click event. If the click happens outside
-    # the boundaries of any text, the method defaults to the buffer position of the cursor.
+    # the boundaries of any text, the method defaults to the buffer position of
+    # the last character in the editor.
     currentScreenPosition = atom.views.getView(@editor).component.screenPositionForMouseEvent mouseEvent
     currentBufferPosition = @editor.bufferPositionForScreenPosition(currentScreenPosition)
 
@@ -125,7 +126,8 @@ class SpellCheckView
 
       corrections = @getCorrections(marker)
       if corrections.length is 0
-        @spellCheckModule.contextMenuEntries.push atom.contextMenu.add {'atom-text-editor': [{label: 'No corrections '}]}
+        noCorrectionsMenuItem = atom.contextMenu.add {'atom-text-editor': [{label: 'No corrections '}]}
+        @spellCheckModule.contextMenuEntries.push {menuItem: noCorrectionsMenuItem}
       else
         for correction in @getCorrections(marker)
           contextMenuEntry = {}

--- a/spec/spell-check-spec.coffee
+++ b/spec/spell-check-spec.coffee
@@ -225,25 +225,6 @@ describe "Spell check", ->
           correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is 'together')[0]
           expect(correctionMenuItem).toBeNull
 
-    describe "when the cursor touches a misspelling that has no corrections", ->
-      it "displays a context menu item saying no corrections found", ->
-        atom.config.set('spell-check.locales', ['en-US'])
-        editor.setText('zxcasdfysyadfyasdyfasdfyasdfyasdfyasydfasdf')
-        advanceClock(editor.getBuffer().getStoppedChangingDelay())
-        atom.config.set('spell-check.grammars', ['source.js'])
-
-        waitsFor ->
-          getMisspellingMarkers().length > 0
-
-        runs ->
-          expect(getMisspellingMarkers()[0].isValid()).toBe true
-
-          editorElement.dispatchEvent(new Event 'contextmenu')
-
-          expect(spellCheckModule.contextMenuEntries.length).toBe 2
-          correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is 'No corrections')[0]
-          expect(correctionMenuItem).toBeDefined
-
   describe "when the editor is destroyed", ->
     it "destroys all misspelling markers", ->
       atom.config.set('spell-check.locales', ['en-US'])

--- a/spec/spell-check-spec.coffee
+++ b/spec/spell-check-spec.coffee
@@ -199,17 +199,20 @@ describe "Spell check", ->
           editorElement.dispatchEvent(new Event 'contextmenu')
 
           # Check that the proper context menu entries are created for the misspelling.
-          # A misspelling will have atleast 1 context menu item for the line separating the corrections.
-          expect(spellCheckModule.contextMenuEntries.length).toBeGreaterThan 1
+          # A misspelling will have atleast 2 context menu items for the lines separating
+          # the corrections.
+          expect(spellCheckModule.contextMenuEntries.length).toBeGreaterThan 2
+          commandName = 'spell-check:correct-misspelling-0'
+          menuItemLabel = 'together'
 
           editorCommands = atom.commands.findCommands(target: editorElement)
-          correctionCommand = (command for command in editorCommands when command.name is 'spell-check:correct-misspelling-0')
+          correctionCommand = (command for command in editorCommands when command.name is commandName)
           expect(correctionCommand).toBeDefined
 
-          correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is 'together')[0]
+          correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is menuItemLabel)[0]
           expect(correctionMenuItem).toBeDefined
 
-          atom.commands.dispatch editorElement, 'spell-check:correct-misspelling-0'
+          atom.commands.dispatch editorElement, commandName
 
           # Check that the misspelling is corrected and the context menu entries are properly disposed.
           expect(editor.getText()).toBe 'together'
@@ -219,11 +222,59 @@ describe "Spell check", ->
           expect(spellCheckModule.contextMenuEntries.length).toBe 0
 
           editorCommands = atom.commands.findCommands(target: editorElement)
-          correctionCommand = (command for command in editorCommands when command.name is 'spell-check:correct-misspelling-0')
+          correctionCommand = (command for command in editorCommands when command.name is commandName)
           expect(correctionCommand).toBeNull
 
-          correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is 'together')[0]
+          correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is menuItemLabel)[0]
           expect(correctionMenuItem).toBeNull
+
+    describe "when the cursor touches a misspelling and adding known words is enabled", ->
+      it "displays the 'Add to Known Words' option and adds that word when the option is selected", ->
+        atom.config.set('spell-check.locales', ['en-US'])
+        editor.setText('zxcasdfysyadfyasdyfasdfyasdfyasdfyasydfasdf')
+        advanceClock(editor.getBuffer().getStoppedChangingDelay())
+        atom.config.set('spell-check.grammars', ['source.js'])
+        atom.config.set('spell-check.addKnownWords', true)
+
+        expect(atom.config.get('spell-check.knownWords').length).toBe 0
+
+        waitsFor ->
+          getMisspellingMarkers().length is 1
+
+        runs ->
+          expect(getMisspellingMarkers()[0].isValid()).toBe true
+          editorElement.dispatchEvent(new Event 'contextmenu')
+
+          # Check that the 'Add to Known Words' entry is added to the context menu.
+          # There should be 1 entry for 'Add to Known Words' and 2 entries for the line separators.
+          expect(spellCheckModule.contextMenuEntries.length).toBe 3
+          commandName = 'spell-check:correct-misspelling-0'
+          menuItemLabel = 'together'
+
+          editorCommands = atom.commands.findCommands(target: editorElement)
+          correctionCommand = (command for command in editorCommands when command.name is commandName)
+          expect(correctionCommand).toBeDefined
+
+          correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is menuItemLabel)[0]
+          expect(correctionMenuItem).toBeDefined
+
+          atom.commands.dispatch editorElement, commandName
+
+          # Check that the misspelling is added as a known word, that there are no more misspelling
+          # markers in the editor, and that the context menu entries are properly disposed.
+          waitsFor ->
+            getMisspellingMarkers().length is 0
+
+          runs ->
+            expect(atom.config.get('spell-check.knownWords').length).toBe 1
+            expect(spellCheckModule.contextMenuEntries.length).toBe 0
+
+            editorCommands = atom.commands.findCommands(target: editorElement)
+            correctionCommand = (command for command in editorCommands when command.name is commandName)
+            expect(correctionCommand).toBeNull
+
+            correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is menuItemLabel)[0]
+            expect(correctionMenuItem).toBeNull
 
   describe "when the editor is destroyed", ->
     it "destroys all misspelling markers", ->

--- a/spec/spell-check-spec.coffee
+++ b/spec/spell-check-spec.coffee
@@ -196,37 +196,32 @@ describe "Spell check", ->
 
         runs ->
           expect(getMisspellingMarkers()[0].isValid()).toBe true
+          editorElement.dispatchEvent(new Event 'contextmenu')
 
-          # Right click on the misspelling.
-          editorElement.dispatchEvent(new MouseEvent 'mousedown',
-            bubbles: true,
-            button: 2,
-          )
+          # Check that the proper context menu entries are created for the misspelling.
+          # A misspelling will have atleast 1 context menu item for the line separating the corrections.
+          expect(spellCheckModule.contextMenuEntries.length).toBeGreaterThan 1
 
-          spellCheckView = spellCheckModule.viewsByEditor.get editor
-
-          expect(spellCheckView.contextMenuCommands.length).toBeGreaterThan 0
           editorCommands = atom.commands.findCommands(target: editorElement)
           correctionCommand = (command for command in editorCommands when command.name is 'spell-check:correct-misspelling-0')
           expect(correctionCommand).toBeDefined
 
-          expect(spellCheckView.contextMenuItems.length).toBeGreaterThan 1 # There is an extra menu item for the line separating the corrections in the context menu
           correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is 'together')[0]
           expect(correctionMenuItem).toBeDefined
 
-          # Select the command to do the correction.
           atom.commands.dispatch editorElement, 'spell-check:correct-misspelling-0'
 
+          # Check that the misspelling is corrected and the context menu entries are properly disposed.
           expect(editor.getText()).toBe 'together'
           expect(editor.getCursorBufferPosition()).toEqual [0, 8]
           expect(getMisspellingMarkers()[0].isValid()).toBe false
 
-          expect(spellCheckView.contextMenuCommands.length).toBe 0
+          expect(spellCheckModule.contextMenuEntries.length).toBe 0
+
           editorCommands = atom.commands.findCommands(target: editorElement)
           correctionCommand = (command for command in editorCommands when command.name is 'spell-check:correct-misspelling-0')
           expect(correctionCommand).toBeNull
 
-          expect(spellCheckView.contextMenuItems.length).toBe 0
           correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is 'together')[0]
           expect(correctionMenuItem).toBeNull
 
@@ -243,16 +238,9 @@ describe "Spell check", ->
         runs ->
           expect(getMisspellingMarkers()[0].isValid()).toBe true
 
-          editorElement.dispatchEvent(new MouseEvent 'mousedown',
-            bubbles: true,
-            button: 2,
-          )
+          editorElement.dispatchEvent(new Event 'contextmenu')
 
-          spellCheckView = spellCheckModule.viewsByEditor.get editor
-
-          expect(spellCheckView.contextMenuCommands.length).toBe 0
-
-          expect(spellCheckView.contextMenuItems.length).toBe 2
+          expect(spellCheckModule.contextMenuEntries.length).toBe 2
           correctionMenuItem = (item for item in atom.contextMenu.itemSets when item.items[0].label is 'No corrections')[0]
           expect(correctionMenuItem).toBeDefined
 


### PR DESCRIPTION
Displaying the corrections for a misspelled word as context menu options as described in #54. This is my first OSS contribution so any feedback on the design or workflow would be great.