### PR TITLE
Don't spell check large files (for now)

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -50,6 +50,9 @@ module.exports =
     @viewsByEditor = new WeakMap
     @contextMenuEntries = []
     @disposable = atom.workspace.observeTextEditors (editor) =>
+      # For now, just don't spell check large files.
+      return if editor.largeFileMode
+
       SpellCheckView ?= require './spell-check-view'
 
       # The SpellCheckView needs both a handle for the task to handle the


### PR DESCRIPTION
Soon we're going to rewrite this package to only check the spelling of the content on screen. Until then, we're just going to avoid spell-checking large files.

/cc @ungb @lee-dohm 

Closes https://github.com/atom/spell-check/pull/170

@steelbrain - I'd prefer to perform the check for `largeFileMode` even earlier. There's no need to even create a `SpellCheckView` for large files.