### PR TITLE
Unicode known words

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "atom-select-list": "^0.7.0",
     "multi-integer-range": "^2.0.0",
     "natural": "^0.4.0",
-    "spellchecker": "3.4.4",
-    "spelling-manager": "1.0.0",
+    "spellchecker": "^3.4.4",
+    "spelling-manager": "^1.0.0",
     "underscore-plus": "^1"
   },
   "repository": "https://github.com/atom/spell-check",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "multi-integer-range": "^2.0.0",
     "natural": "^0.4.0",
     "spellchecker": "3.4.4",
-    "spelling-manager": "0.3.0",
+    "spelling-manager": "1.0.0",
     "underscore-plus": "^1"
   },
   "repository": "https://github.com/atom/spell-check",

--- a/spec/known-unicode-spec-checker.coffee
+++ b/spec/known-unicode-spec-checker.coffee
@@ -1,0 +1,8 @@
+SpecChecker = require './spec-checker'
+
+class KnownUnicodeSpecChecker extends SpecChecker
+  constructor: ->
+    super("known-unicode", false, ["абырг"])
+
+checker = new KnownUnicodeSpecChecker
+module.exports = checker

--- a/spec/spec-checker.coffee
+++ b/spec/spec-checker.coffee
@@ -1,3 +1,6 @@
+# This is functionally identical to the known words checker except that it
+# is intended to be immutable while running tests. This means the constructor
+# adds the words instead of calling `add` directly.
 class SpecChecker
   spelling: null
   checker: null

--- a/spec/spell-check-spec.coffee
+++ b/spec/spell-check-spec.coffee
@@ -469,3 +469,48 @@ describe "Spell check", ->
       runs ->
         editor.destroy()
         expect(getMisspellingMarkers().length).toBe 0
+
+    it "treats unknown Unicode words as incorrect", ->
+      spellCheckModule.consumeSpellCheckers require.resolve('./eot-spec-checker.coffee')
+      atom.config.set('spell-check.knownWords', [])
+      atom.config.set('spell-check.locales', ['en-US'])
+      atom.config.set('spell-check.useLocales', true)
+      editor.setText('こんいちば eot')
+      atom.config.set('spell-check.grammars', ['source.js'])
+
+      waitsFor ->
+        getMisspellingMarkers().length is 2
+
+      runs ->
+        editor.destroy()
+        expect(getMisspellingMarkers().length).toBe 0
+
+    it "treats known Unicode words as correct", ->
+      spellCheckModule.consumeSpellCheckers require.resolve('./eot-spec-checker.coffee')
+      atom.config.set('spell-check.knownWords', ['GitHub', '!github', 'codez', 'こんいちば'])
+      atom.config.set('spell-check.locales', ['en-US'])
+      atom.config.set('spell-check.useLocales', true)
+      editor.setText('こんいちば eot')
+      atom.config.set('spell-check.grammars', ['source.js'])
+
+      waitsFor ->
+        getMisspellingMarkers().length is 1
+
+      runs ->
+        editor.destroy()
+        expect(getMisspellingMarkers().length).toBe 0
+
+    it "treats single known Unicode words as correct", ->
+      spellCheckModule.consumeSpellCheckers require.resolve('./eot-spec-checker.coffee')
+      atom.config.set('spell-check.knownWords', ['GitHub', '!github', 'codez', 'こんいちば'])
+      atom.config.set('spell-check.locales', ['en-US'])
+      atom.config.set('spell-check.useLocales', true)
+      editor.setText('こんいちば eot')
+      atom.config.set('spell-check.grammars', ['source.js'])
+
+      waitsFor ->
+        getMisspellingMarkers().length is 1
+
+      runs ->
+        editor.destroy()
+        expect(getMisspellingMarkers().length).toBe 0


### PR DESCRIPTION
### Requirements

I've added a positive and negative test as the first commit to prove the defect and then a second commit for the correction.

### Description of the Change

The "known words" part of `spell-check` could not handle non-Latin words due to the use of the `\w` in the regular expressions. This is a known problem because of Javascript's poor Unicode support. To fix it, `spelling-manager` was updated to use Unicode ranges for character identification instead of `\w`. In specific, `\p{L}\p{M}\p{N}\p{Pc}`. It does not use `[\p{InEnclosedAlphanumerics}&&\p{So}]` as suggested in #219 because of poor support of logical character ranges.

### Alternate Designs

Previous iterations of `spelling-manager` went with the `\w` because of common usage. Since this was a centralized function used by `spell-check` known words and `spell-check-project`, it seemed like a logical place to update in the central library and then update changes.

### Benefits

Currently, Unicode sequences such as `こんいちば`, `नमस्ते`, `здравствуйте`, and `γειά σου` cannot be added to the known words. Instead, they will always be incorrectly marked as a typo.

### Possible Drawbacks

Using a more complex regular expression has the possibility of not including the same characters as `\w`, but `\p{L}\p{M}\p{N}\p{Pc}` appears to cover the more limited range previously used.

### Applicable Issues

#219 
