### PR TITLE
Don't watch editors more than once if they're re-added to the workspace

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -42,6 +42,8 @@ module.exports =
     @viewsByEditor = new WeakMap
     @contextMenuEntries = []
     @subs.add atom.workspace.observeTextEditors (editor) =>
+      return if @viewsByEditor.has(editor)
+
       # For now, just don't spell check large files.
       return if editor.largeFileMode
 


### PR DESCRIPTION
This will prevent this package from providing its functionality to editors more than once in case they get added to the workspace, then removed from it and finally added back.

/cc: @nathansobo @jasonrudolph