### PR TITLE
fix the github README link

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "text.plain",
         "text.plain.null-grammar"
       ],
-      "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package-) for more information on finding the correct scope for a specific language.",
+      "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package) for more information on finding the correct scope for a specific language.",
       "order": "1"
     },
     "useLocales": {


### PR DESCRIPTION
### Requirements

None

### Description of the Change

Fix the github README link:
Fix the wrong anchor (just removed the trailing `-`).

### Alternate Designs

N.A.

### Benefits

Better user experience

### Possible Drawbacks

none

### Applicable Issues

none
