### PR TITLE
Add config option Disabled Grammars to ignore scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ By default spell check is enabled for the following files:
 * Git Commit Message
 * AsciiDoc
 
-You can override this from the _Spell Check_ settings in the Settings View (<kbd>cmd-,</kbd>). The Grammars config option is a list of scopes for which the package will check for spelling errors.
+You can override this from the _Spell Check_ settings in the Settings View (<kbd>cmd-,</kbd>). The Grammars config option is a list of scopes for which the package will check for spelling errors, and the Disabled Grammars config option is a list of scopes for which the package will skip checking for spelling errors in files for which the main scope has been enabled.
 
 To enable _Spell Check_ for your current file type: put your cursor in the file, open the [Command Palette](https://github.com/atom/command-palette)
 (<kbd>cmd-shift-p</kbd>), and run the `Editor: Log Cursor Scope` command. This will trigger a notification which will contain a list of scopes. The first scope that's listed is the one you should add to the list of scopes in the settings for the _Spell Check_ package. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.
+
+To disable _Spell Check_ for all instances of a specific scope within a file's main scope for which the package is enabled, put your cursor in any instance of the type of section you want ignored. For example, if you have Markdown files enabled, but you don't want any URLs in `[link_text](url)` type links to to be checked for spelling, you'd put your cursor anywhere within the URL part, open the Command Palette (see previous paragraph), and enter `Editor: Log Cursor Scope`. In this example, the first scope is the main scope for the file, the second is the scope for the whole link, and the third is the scope for the URL within the link, which is the one you'd want to add to Disabled Grammars. Be aware that `Editor: Log Cursor Scope` does __not__ always return three scopes, however, the scopes are always returned in order of specificity, making it fairly easy to figure out which scope is the one you need.
+
+*Note:* Disabled Grammars should not be used to ignore whole files. Instead, just make sure the scope for the file type you don't want checked isn't in Grammars.
 
 ## Changing the dictionary
 

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -80,8 +80,25 @@ class SpellCheckView
     @initializeMarkerLayer()
 
   addMarkers: (misspellings) ->
+    # Get disabled grammars from config
+    disabledGrammars = atom.config.get('spell-check.disabledGrammars')
+
     for misspelling in misspellings
-      @markerLayer.markBufferRange(misspelling, {invalidate: 'touch'})
+      misspellingEnabled = true
+
+      # Loop through the range of positions until a
+      # disabled grammar is found in a position's grammars,
+      # or the end of the misspelling is reached
+      grammars = @editor
+        .scopeDescriptorForBufferPosition(misspelling[0])
+        .scopes
+      for grammar in grammars
+        if _.contains(disabledGrammars, grammar)
+          misspellingEnabled = false
+          break
+
+      if misspellingEnabled
+        @markerLayer.markBufferRange(misspelling, {invalidate: 'touch'})
 
   updateMisspellings: ->
     @taskWrapper.start @editor, (misspellings) =>

--- a/package.json
+++ b/package.json
@@ -27,13 +27,19 @@
         "text.plain.null-grammar"
       ],
       "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package) for more information on finding the correct scope for a specific language.",
-      "order": "1"
+      "order": 1
+    },
+    "disabledGrammars": {
+      "type": "array",
+      "default": [],
+      "description": "List of scopes that will not be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package) for more information on finding the correct scope for a specific part of a language.",
+      "order": 2
     },
     "useLocales": {
       "type": "boolean",
       "default": "true",
       "description": "If unchecked, then the locales below will not be used for spell-checking and no spell-checking using system dictionaries will be provided.",
-      "order": "2"
+      "order": 3
     },
     "locales": {
       "type": "array",
@@ -42,7 +48,7 @@
         "type": "string"
       },
       "description": "List of locales to use for the system spell-checking. Examples would be `en-US` or `de-DE`. For Windows, the appropriate language must be installed using *Region and language settings*. If this is blank, then the default language for the user will be used.",
-      "order": 3
+      "order": 4
     },
     "localePaths": {
       "type": "array",
@@ -51,19 +57,19 @@
         "type": "string"
       },
       "description": "List of additional paths to search for dictionary files. If a locale cannot be found in these, the internal code will attempt to find it using common search paths. This is used for Linux and OS X.",
-      "order": 4
+      "order": 5
     },
     "knownWords": {
       "type": "array",
       "default": [],
       "description": "List words that are considered correct even if they do not appear in any other dictionary. Words with capitals or ones that start with `!` are case-sensitive.",
-      "order": 5
+      "order": 6
     },
     "addKnownWords": {
       "type": "boolean",
       "default": false,
       "description": "If checked, then the suggestions will include options to add to the known words list above.",
-      "order": 6
+      "order": 7
     }
   },
   "devDependencies": {

--- a/styles/spell-check.atom-text-editor.less
+++ b/styles/spell-check.atom-text-editor.less
@@ -1,5 +1,5 @@
 .spell-check-misspelling .region {
-  border-bottom: 2px dotted hsla(0, 100%, 60%, 0.75);
+  border-bottom: 1px dotted hsla(0, 100%, 60%, 0.75);
 }
 
 .spell-check-corrections {


### PR DESCRIPTION
### Description of the Change

In the config you can now add grammars under Disabled Grammars to have them ignored in files which have their main scope enabled. I also changed the underline from 2px to 1px because 2px was ugly as hell, but that part doesn't have to be merged with the rest of the commit, obviously. I also documented everything, but didn't bump the version, because I figured I'd let you bump it however you want if it gets merged.

### Benefits

You can now disabled specific grammars within main grammars that are enabled.

### Why Should This Be In Core?

Look below at how many freaking duplicate issues there are about this...

This commit is similar to commit #157, with some differences.
Fixes #2, #117, #118, #124, #126, #169, #180, and #204.

*__For those who don't want to wait for this, or an alternate implementation to be merged into core spell-check...__*

Follow the instructions at the top of the [spell-check-plus README](https://github.com/gucciferXCIV/spell-check-plus).

Edit [12/15/17 8:07am EST]: I removed the instructions themselves and replaced them with the link above because a pull request probably isn't the best place for instructions for other packages.