### PR TITLE
Remove editors from `spellCheckViews` after destruction

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -66,6 +66,14 @@ module.exports =
         view: spellCheckView
         active: true
         editor: editor
+
+      # Make sure that the view is cleaned up on editor destruction.
+      destroySub = editor.onDidDestroy () =>
+        spellCheckView.destroy()
+        delete spellCheckViews[editorId]
+        @subs.remove destroySub
+      @subs.add destroySub
+
       @viewsByEditor.set editor, spellCheckView
 
   deactivate: ->

--- a/spec/spell-check-spec.coffee
+++ b/spec/spell-check-spec.coffee
@@ -290,6 +290,8 @@ describe "Spell check", ->
       runs ->
         editor.destroy()
         expect(getMisspellingMarkers().length).toBe 0
+        # Check that all the views have been cleaned up.
+        expect(spellCheckModule.updateViews().length).toBe 0
 
   describe "when using checker plugins", ->
     it "no opinion on input means correctly spells", ->


### PR DESCRIPTION
Fixes #201. (Includes a spec to guard against this)

### Description of the Change

See issue #201 - `spell-check` retains a global map of all opened editors, and does not release them upon editor destruction.

### Benefits

Fewer memory leaks (this leaks entire editor objects, although thankfully the impact is generally limited because `TextEditor` nulls out various references during its destruction).