### PR TITLE
Fallback to the dictionary path provided by node-spellchecker.

### DIFF
--- a/lib/system-checker.coffee
+++ b/lib/system-checker.coffee
@@ -74,8 +74,7 @@ class SystemChecker
 
     # Try the packaged library inside the node_modules. `getDictionaryPath` is
     # not available, so we have to fake it. This will only work for en-US.
-    path = require 'path'
-    vendor = path.join __dirname, "..", "node_modules", "spellchecker", "vendor", "hunspell_dictionaries"
+    vendor = spellchecker.getDictionaryPath()
     if @spellchecker.setDictionary @locale, vendor
       return
 


### PR DESCRIPTION
### Requirements

Windows 7 doesn't correct use the packaged `en-US` dictionary when no settings are included in the dictionary.

### Description of the Change

On Windows 7 (#162), `spell-check` does not correctly fall back to `en-US` dictionary inside the `node-spellcheck` because we ship a ASAR-packed archive. The fallback directory search was based on the original version of `node-spellcheck`'s check for local director but did not include the "unpacked" logic that is there today. In version 3.4.4 of `node-spellcheck`, a method was provided to get the library's search path which we are now using instead of duplicating the (incorrect) logic that doesn't handle ASAR packing.

### Alternate Designs

Originally, we copied the search path from `node-spellcheck`. An alternative is to update our search path logic to use the same `try`/`catch` logic to handle archives. This seemed more fragile and harder to maintain.

### Benefits

It works on Windows 7.

`node-spellcheck` will always agree with `spell-check` in guessing the vendor path.

### Possible Drawbacks

The path that was previously used may be different than the one `node-spellcheck` provides.

### Applicable Issues

I have spent a year trying to get Windows 7 to package on a local machine and have failed. I can't fully test with a ASAR-packaged version of Atom.
