### PR TITLE
Add excludedScopes setting

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -20,6 +20,13 @@ module.exports =
 
     manager = @getInstance @globalArgs
 
+    @excludedScopeRegexLists = []
+    @subs.add atom.config.onDidChange 'spell-check.excludedScopes', ({newValue}) =>
+      @excludedScopeRegexLists = newValue.map (excludedScope) ->
+        for className in excludedScope.split(/\s+/)[0].split('.') when className
+          new RegExp("\\b#{className}\\b")
+      @updateViews()
+
     @subs.add atom.config.onDidChange 'spell-check.locales', ({newValue, oldValue}) =>
       @globalArgs.locales = newValue
       manager.setGlobalArgs @globalArgs

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -81,7 +81,9 @@ class SpellCheckView
 
   addMarkers: (misspellings) ->
     for misspelling in misspellings
-      @markerLayer.markBufferRange(misspelling, {invalidate: 'touch'})
+      scope = @editor.scopeDescriptorForBufferPosition(misspelling[0])
+      unless @scopeIsExcluded(scope)
+        @markerLayer.markBufferRange(misspelling, {invalidate: 'touch'})
 
   updateMisspellings: ->
     @taskWrapper.start @editor, (misspellings) =>
@@ -169,3 +171,9 @@ class SpellCheckView
       entry.menuItem?.dispose()
 
     @spellCheckModule.contextMenuEntries = []
+
+  scopeIsExcluded: (scopeDescriptor, excludedScopes) ->
+    @spellCheckModule.excludedScopeRegexLists.some (regexList) ->
+      scopeDescriptor.scopes.some (scopeName) ->
+        regexList.every (regex) ->
+          regex.test(scopeName)

--- a/package.json
+++ b/package.json
@@ -27,13 +27,22 @@
         "text.plain.null-grammar"
       ],
       "description": "List of scopes for languages which will be checked for misspellings. See [the README](https://github.com/atom/spell-check#spell-check-package) for more information on finding the correct scope for a specific language.",
-      "order": "1"
+      "order": 1
+    },
+    "excludedScopes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": [],
+      "description": "List of sub-scopes that will be ignored. Specify the most detailed scope to avoid ignoring otherwise relevant text. The scopes will be parsed as regular expressions. See [the README](https://github.com/atom/spell-check#spell-check-package-) for more information on finding the correct scope for a specific language.",
+      "order": 2
     },
     "useLocales": {
       "type": "boolean",
       "default": "true",
       "description": "If unchecked, then the locales below will not be used for spell-checking and no spell-checking using system dictionaries will be provided.",
-      "order": "2"
+      "order": 3
     },
     "locales": {
       "type": "array",
@@ -42,7 +51,7 @@
         "type": "string"
       },
       "description": "List of locales to use for the system spell-checking. Examples would be `en-US` or `de-DE`. For Windows, the appropriate language must be installed using *Region and language settings*. If this is blank, then the default language for the user will be used.",
-      "order": 3
+      "order": 4
     },
     "localePaths": {
       "type": "array",
@@ -51,19 +60,19 @@
         "type": "string"
       },
       "description": "List of additional paths to search for dictionary files. If a locale cannot be found in these, the internal code will attempt to find it using common search paths. This is used for Linux and OS X.",
-      "order": 4
+      "order": 5
     },
     "knownWords": {
       "type": "array",
       "default": [],
       "description": "List words that are considered correct even if they do not appear in any other dictionary. Words with capitals or ones that start with `!` are case-sensitive.",
-      "order": 5
+      "order": 6
     },
     "addKnownWords": {
       "type": "boolean",
       "default": false,
       "description": "If checked, then the suggestions will include options to add to the known words list above.",
-      "order": 6
+      "order": 7
     }
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #157
Closes #228
Fixes #117

### Motivation

Currently, spell-checking is enabled and disabled via a setting called `spell-check.grammars` whose value is a list of top-level grammar names for which to perform spell checking. However, people often want to disable spell-checking for particular syntactic construct within a language for which spell-checking is otherwise enabled (for example, to prevent certain keywords in a LaTeX document from being marked as misspelled).

### Solution

This PR adds a new setting called `spell-check.excludedScopes`. The value of this setting is an array of scope selectors (e.g. `['.support.function.tex', '.link']`). Currently, nested selectors are not supported: you can only use combinations of one or more class names.

I think that in the future, we could replace the existing `spell-check.grammars` setting with a more general `spell-check.includedScopes` setting that would allow arbitrary selectors. Then, by combining `includedScopes` and `excludedScopes`, the user would be able to customize the presence or absence of spell-checking in a very fine-grained way, fixing #19, #118, #126. This is more complicated to implement however; it would probably require a bigger rework.

### Implementation

We currently spell-check the entire document at once (as opposed to just the on-screen lines), so in order to avoid performance problems, we need to be careful about adding any computations to the code path that creates the markers. I have implemented support for a restricted set of scope selectors (those without nesting) using simple regexes which are precomputed.

I considered implementing full scope selector support using the [`ScopedPropertyStore`](http://github.com/atom/scoped-property-store), but I think that reading from that store for every single misspelling marker would be very expensive.

PR #157 implemented similar functionality but with a different interface: users could provide *regular expressions* that would be tested against scope descriptors. This works in practice but is brittle because it relies on the user knowing the order of class names in a single element of a scope descriptor (e.g. `support.function` vs `function.support`). It is also inconsistent with our usual method of matching scopes via scope selectors.