### PR TITLE
Add postinstall hook to remove the webworker-threads module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "atom-select-list": "^0.7.0",
     "multi-integer-range": "^2.0.0",
     "natural": "^0.4.0",
+    "rimraf": "^2.6.2",
     "spellchecker": "^3.4.4",
     "spelling-manager": "^1.0.0",
     "underscore-plus": "^1"
@@ -84,5 +85,8 @@
         "^1.0.0": "consumeSpellCheckers"
       }
     }
+  },
+  "scripts": {
+    "postinstall": "node script/postinstall.js"
   }
 }

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -9,6 +9,9 @@ const path = require('path')
 // webworker-threads is a dependency of natural, which is a dependency of
 // spelling-manager, which is a dependency of this package.
 // See: https://github.com/atom/spell-check/issues/67#issuecomment-380298141
+//
+// TODO Revert bceff78 once the spelling-manager module no longer depends on
+// natural. See https://github.com/atom/spell-check/issues/67#issuecomment-380471302.
 const webworkerThreadsPath = path.join('node_modules', 'webworker-threads')
 const rimraf = require('rimraf')
 rimraf.sync(webworkerThreadsPath)

--- a/script/postinstall.js
+++ b/script/postinstall.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+// Remove the webworker-threads module in hopes of resolving the issue
+// described in https://github.com/atom/spell-check/issues/67#issuecomment-377808833.
+//
+// webworker-threads is a dependency of natural, which is a dependency of
+// spelling-manager, which is a dependency of this package.
+// See: https://github.com/atom/spell-check/issues/67#issuecomment-380298141
+const webworkerThreadsPath = path.join('node_modules', 'webworker-threads')
+const rimraf = require('rimraf')
+rimraf.sync(webworkerThreadsPath)


### PR DESCRIPTION
In an attempt to resolve the problem described in https://github.com/atom/spell-check/issues/67#issuecomment-377808833, this pull request adds a postinstall hook to delete the webworker-threads module as described in https://github.com/atom/spell-check/issues/67#issuecomment-380298141.

This is admittedly a hack, and I'm not _certain_ that it will resolve the issue, but we'll give it a shot.

If this does resolve the issue, we can consider it a temporary workaround, and we can remove this workaround when the spelling-manager module no longer depends on the natural module (https://github.com/atom/spell-check/issues/67#issuecomment-380471302), or when the natural module makes the webworker-threads module a peer dependency (https://github.com/NaturalNode/natural/issues/368) instead of an optional dependency.

/fyi @dmoonfire @maxbrunsfeld 