### PR TITLE
Added the ability to show loading errors as a transient popup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,17 @@
       "default": false,
       "description": "If checked, then the suggestions will include options to add to the known words list above.",
       "order": 7
+    },
+    "noticesMode": {
+      "type": "string",
+      "default": "both",
+      "description": "Choose where loading errors and other notices are displayed: popup, console, or both.",
+      "order": 8,
+      "enum": [
+        { "value": "both", "description": "Display notices in popups and in the console" },
+        { "value": "popup", "description": "Display notices only in popups" },
+        { "value": "console", "description": "Display notices only on the console" }
+      ]
     }
   },
   "devDependencies": {


### PR DESCRIPTION
* Added an enum setting to disable error reporting.
* Default to reporting both to the console and popup.
* Refactored to be able to show the list of all paths used to search for
dictionaries.

### Description of the Change

To make it easier to identify quickly there are problems loading a system dictionary, some sort of notification would be helpful. Having a list of all the paths searched would also make it easier in the process of implementing/using relative paths for dictionaries. This patch is to have a popup show on loading errors to let the user know there is a problem and some diagnostics information.

### Alternate Designs

I considered only reporting the paths to the console but it felt like it was an easily hidden spot that made it difficult to identify where the problem was happening.

### Benefits

The user will be able to identify loading or locale errors sooner.

### Possible Drawbacks

If they have a lot of locales and a poor location, this will cause a wall of red.

### Applicable Issues

* #203, #195: Knowing *which* relative path will help with debugging.