### PR TITLE
Added the ability to have a relative path for dictionary lookup.

### DIFF
--- a/lib/system-checker.coffee
+++ b/lib/system-checker.coffee
@@ -1,4 +1,5 @@
 spellchecker = require 'spellchecker'
+pathspec = require 'atom-pathspec'
 
 class SystemChecker
   spellchecker: null
@@ -56,7 +57,7 @@ class SystemChecker
 
     # Check the paths supplied by the user.
     for path in @paths
-      searchPaths.push path
+      searchPaths.push pathspec.getPath(path)
 
     # For Linux, we have to search the directory paths to find the dictionary.
     if /linux/.test process.platform

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "./lib/main",
   "description": "Highlights misspelled words and shows possible corrections.",
   "dependencies": {
+    "atom-pathspec": "^0.0.0",
     "atom-select-list": "^0.7.0",
     "multi-integer-range": "^2.0.0",
     "natural": "^0.4.0",
@@ -80,9 +81,18 @@
       "description": "Choose where loading errors and other notices are displayed: popup, console, or both.",
       "order": 8,
       "enum": [
-        { "value": "both", "description": "Display notices in popups and in the console" },
-        { "value": "popup", "description": "Display notices only in popups" },
-        { "value": "console", "description": "Display notices only on the console" }
+        {
+          "value": "both",
+          "description": "Display notices in popups and in the console"
+        },
+        {
+          "value": "popup",
+          "description": "Display notices only in popups"
+        },
+        {
+          "value": "console",
+          "description": "Display notices only on the console"
+        }
       ]
     }
   },


### PR DESCRIPTION
* User can use pseudo-drives to create relative paths:
  * Implement [atom-pathspec](https://www.npmjs.com/package/atom-pathspec)
  * Issue #203 would use `application:../dictionaries` for searching.
  * Addresses some issues referenced in #204.
  * See above link for how to use home-, download-, and configuration-relative paths.
* Added no new tests because couldn't find a way of referencing relative paths in a test.

### Requirements

* All new code requires tests to ensure against regressions

Not sure how to write tests that use a relative path since that is outside of the test.

### Description of the Change

Issue #203 is asking for the ability to have a relative path for dictionary search paths for portable installations. This introduces the concept of pseudo-drives for path specifications to allow Electron to use those as a root and enable paths relative to various different roots like the application, the user's home, configuration, or downloads folder.

### Alternate Designs

There seemed to be too many "relative to what" questions involved so I wasn't sure of another way to implement this.

### Benefits

This will allow portable installations to have custom dictionaries.

### Possible Drawbacks

* It adds yet another layer to the path resolution code.
* There is no existing patterns for handling "relative to" path specifications.

### Applicable Issues

* #203: This would allow portable installations.
* #204: A combination issue including #203.