### PR TITLE
Allow for ES6 checkers that are exported as a default class.

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -15,12 +15,16 @@ The `nameOfFunctionToProvideSpellCheck` function may return either a single `req
     provideSpellCheck: ->
       require.resolve './project-checker.coffee'
 
-The path given must resolve to a singleton instance of a class.
+The path given must either resolve to a singleton instance of a class or a default export in a ES6 module.
 
     class ProjectChecker
       # Magical code
     checker = new ProjectChecker()
     module.exports = checker
+
+For a default using Typescript:
+
+    export default class ProjectChecker {}
 
 See the `spell-check-project` for an example implementation.
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,15 +11,22 @@ module.exports =
     # arguments and pass them into the task. Whenever these change, we'll update
     # the object with the parameters and resend it to the task.
     @globalArgs =
+      # These are the settings that are part of the main `spell-check` package.
       locales: atom.config.get('spell-check.locales'),
       localePaths: atom.config.get('spell-check.localePaths'),
       useLocales: atom.config.get('spell-check.useLocales'),
       knownWords: atom.config.get('spell-check.knownWords'),
       addKnownWords: atom.config.get('spell-check.addKnownWords'),
+
+      # Collection of all the absolute paths to checkers which will be
+      # `require` on the process side to load the checker. We have to do this
+      # because we can't pass the actual objects from the main Atom process to
+      # the background safely.
       checkerPaths: []
 
     manager = @getInstance @globalArgs
 
+    # Hook up changes to the configuration settings.
     @excludedScopeRegexLists = []
     @subs.add atom.config.onDidChange 'spell-check.excludedScopes', ({newValue}) =>
       @excludedScopeRegexLists = newValue.map (excludedScope) ->
@@ -54,6 +61,8 @@ module.exports =
       # For now, just don't spell check large files.
       return if editor.largeFileMode
 
+      # Defer loading the spell check view if we actually need it. This also
+      # avoids slowing down Atom's startup by getting it loaded on demand.
       SpellCheckView ?= require './spell-check-view'
 
       # The SpellCheckView needs both a handle for the task to handle the

--- a/lib/spell-check-manager.coffee
+++ b/lib/spell-check-manager.coffee
@@ -50,7 +50,16 @@ class SpellCheckerManager
       @knownWordsChecker = null
 
   addCheckerPath: (checkerPath) ->
+    # Load the given path via require.
     checker = require checkerPath
+
+    # If this a ES6 module, then we need to construct it. We require
+    # the coders to export it as `default` since we don't have another
+    # way of figuring out which object to instantiate.
+    if checker.default
+       checker = new checker.default()
+
+    # Add in the resulting checker.
     @addPluginChecker checker
 
   addPluginChecker: (checker) ->

--- a/lib/spell-check-manager.coffee
+++ b/lib/spell-check-manager.coffee
@@ -57,7 +57,7 @@ class SpellCheckerManager
     # the coders to export it as `default` since we don't have another
     # way of figuring out which object to instantiate.
     if checker.default
-       checker = new checker.default()
+      checker = new checker.default()
 
     # Add in the resulting checker.
     @addPluginChecker checker


### PR DESCRIPTION
### Requirements

When I originally wrote the plugin infrastructure, I had to use `require.resolve` to pass in the paths to the checker for the secondary processes. At the time, I was only using Coffee and ES5, so I just created a new version of the object and returned that.

When using later versions of Typescript and ES6, this is more difficult to do because of how ES6 modules work.

### Description of the Change

When we load the checker via `require`, check to see if `require.default` exists. If it does, then treat it as a class that needs to be `new checker.default()`.

### Alternate Designs

Getting Typescript to generate a top-level instantiated object is difficult but not impossible. I thought it was better to allow working with the language and handling the two cases in the `spell-check` code instead of jumping through hoops with the plugins.

### Benefits

Easier development of plugins.

### Possible Drawbacks

A possibility of a class having a `default` property that is incorrectly tried to be called.

### Applicable Issues

This is related to my work on getting additional plugins working with spell-checking.