### PR TITLE
Ensure excluded scopes are respected

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -21,8 +21,8 @@ module.exports =
     manager = @getInstance @globalArgs
 
     @excludedScopeRegexLists = []
-    @subs.add atom.config.onDidChange 'spell-check.excludedScopes', ({newValue}) =>
-      @excludedScopeRegexLists = newValue.map (excludedScope) ->
+    @subs.add atom.config.observe 'spell-check.excludedScopes', (excludedScopes) =>
+      @excludedScopeRegexLists = excludedScopes.map (excludedScope) ->
         for className in excludedScope.split(/\s+/)[0].split('.') when className
           new RegExp("\\b#{className}\\b")
       @updateViews()

--- a/lib/spell-check-view.coffee
+++ b/lib/spell-check-view.coffee
@@ -67,7 +67,10 @@ class SpellCheckView
 
     if @spellCheckCurrentGrammar()
       @buffer = @editor.getBuffer()
-      @bufferDisposable = @buffer.onDidStopChanging => @updateMisspellings()
+      @bufferDisposable = new CompositeDisposable(
+        @buffer.onDidStopChanging => @updateMisspellings(),
+        @editor.onDidTokenize => @updateMisspellings()
+      )
       @updateMisspellings()
 
   spellCheckCurrentGrammar: ->

--- a/spec/spell-check-spec.js
+++ b/spec/spell-check-spec.js
@@ -58,7 +58,7 @@ describe('Spell check', function () {
       'class SpeledWrong {}'
     )
     atom.config.set('spell-check.locales', ['en-US'])
-    atom.config.set('spell-check.grammars', ['source.js'])
+    atom.config.set('spell-check.grammars', ['source.js', 'text.plain.null-grammar'])
     atom.config.set('spell-check.excludedScopes', ['.function.entity'])
 
     {
@@ -88,6 +88,17 @@ describe('Spell check', function () {
       expect(markers.map(marker => marker.getBufferRange())).toEqual([
         [[0, 0], [0, 11]],
         [[1, 9], [1, 20]]
+      ])
+    }
+
+    {
+      atom.grammars.assignLanguageMode(editor, null)
+      await conditionPromise(() => getMisspellingMarkers().length === 3)
+      const markers = getMisspellingMarkers()
+      expect(markers.map(marker => marker.getBufferRange())).toEqual([
+        [[0, 0], [0, 11]],
+        [[1, 9], [1, 20]],
+        [[2, 6], [2, 17]]
       ])
     }
   })


### PR DESCRIPTION
Fixes #238

There were two bugs in the the logic for excluding scopes:

1. Due to the wrong `Config` method being called, the excluded scopes were only used when the `excludedScopes` setting *changed*, not during initialization of the packages.
2. The misspellings needed to be updated after the buffer finished tokenizing, because when initially spell-checking a file, the scopes might not be present.