### PR TITLE
Fix AppVeyor builds against Atom beta with Electron 2.0.1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
   - ATOM_CHANNEL: beta
 
 install:
-  - ps: Install-Product node 4
+  - ps: Install-Product node 6
 
 build_script:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: "{build}"
 
+image: Visual Studio 2015
 platform: x64
 
 branches:


### PR DESCRIPTION
spell-check is no longer building correctly against Atom Beta due to some conflict between Electron 2.0 and the build tools on AppVeyor.