### PR TITLE
Fix large file check

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -3,6 +3,8 @@
 SpellCheckView = null
 spellCheckViews = {}
 
+LARGE_FILE_SIZE = 2 * 1024 * 1024
+
 module.exports =
   activate: ->
     @subs = new CompositeDisposable
@@ -59,7 +61,7 @@ module.exports =
       return if @viewsByEditor.has(editor)
 
       # For now, just don't spell check large files.
-      return if editor.largeFileMode
+      return if editor.getBuffer().getLength() > LARGE_FILE_SIZE
 
       # Defer loading the spell check view if we actually need it. This also
       # avoids slowing down Atom's startup by getting it loaded on demand.


### PR DESCRIPTION
We've received internal reports that `spell-check` still doesn't seem to have great performance characteristics for very large files (not sure if there are plans to fix this :P)

Unfortunately, the check to disable spell-check on large files was using `editor.largeFileMode`, which is no longer a supported API (It's now part of `TextMateLanguageMode`, which we can't really count on).

https://github.com/atom/atom/search?q=largeFileMode&unscoped_q=largeFileMode

Instead, we'll just get the buffer's length and compare it to our own `LARGE_FILE_SIZE` (set to 2MB, the same as the one in `TextMateLanguageMode`.)