### PR TITLE
Ignore unregistered TextEditors

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -150,6 +150,10 @@ module.exports =
       return
     editorId = atom.workspace.getActiveTextEditor().id
 
+    if not spellCheckViews.hasOwnProperty(editorId)
+      # The editor was never registered with a view, ignore it
+      return
+
     if spellCheckViews[editorId]['active']
       # deactivate spell check for this {editor}
       spellCheckViews[editorId]['active'] = false


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

If the `TextEditor` was ignored by the observe callback on all `TextEditor`s there was a good reason for that (currently large files). Respect that and handle when the `TextEditor` isn't currently in the list of `spellCheckViews`.

### Alternate Designs

There is probably a more "CoffeeScripty" way of doing this check, but as this code should be converted to JavaScript anyway this isn't really relevant.

### Benefits

No error is thrown to the user.

### Possible Drawbacks

No feedback to the user that their command did nothing if they _wanted_ to spell check a `TextEditor` that was ignored.

### Applicable Issues

Fixes #210.