### PR TITLE
⬆️ node-spellchecker@3.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "atom-select-list": "^0.7.0",
     "multi-integer-range": "^2.0.0",
     "natural": "^0.4.0",
-    "spellchecker": "^3.5.2",
+    "spellchecker": "^3.5.3",
     "spelling-manager": "^1.1.0",
     "underscore-plus": "^1"
   },


### PR DESCRIPTION
`node-spellchecker@3.5.3` contains [a fix](https://github.com/atom/node-spellchecker/pull/108) for Node v12 builds (which will be relevant when upgrading to Electron v5).