### PR TITLE
Split checkers to explictly handle macOS/Windows system checkers verses locale-based checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ If your Windows user does not have Administration privileges, you'll need to do 
 
 Once the additional language is added, Atom will need to be restarted.
 
-You can set the `SPELLCHECKER_PREFER_HUNSPELL` environment variable to request the use of the built-in hunspell spell checking library instead of the system dictionaries. If the environment variable is not set, then the `en-US` dictionaries found in the Atom's installation directory will not be used.
+*Previously, setting `SPELLCHECKER_PREFER_HUNSPELL` environment variable would change how checking works. Now this is controlled by the system and locale checker to use the operating system version or Hunspell respectively.*
+
+If locale is not set, Atom will attempt to use the current locale from the environment variable; if that is missing, `en-US` will be used. The dictionary for `en-US` is shipping with Atom but all other locale-based checkers will need to be downloaded from another source.
 
 ### Debian, Ubuntu, and Mint
 

--- a/lib/checker-env.coffee
+++ b/lib/checker-env.coffee
@@ -1,0 +1,10 @@
+module.exports =
+  isLinux: -> /linux/.test process.platform
+  isWindows: -> /win32/.test process.platform # TODO: Windows < 8 or >= 8
+  isDarwin: -> /darwin/.test process.platform
+  preferHunspell: -> !!process.env.SPELLCHECKER_PREFER_HUNSPELL
+
+  isSystemSupported: -> @isWindows() or @isDarwin()
+  isLocaleSupported: -> true
+
+  useLocales: -> @isLinux() or @isWindows() or @preferHunspell()

--- a/lib/known-words-checker.coffee
+++ b/lib/known-words-checker.coffee
@@ -28,10 +28,11 @@ class KnownWordsChecker
   check: (args, text) ->
     ranges = []
     checked = @checker.check text
+    id = @getId()
     for token in checked
       if token.status is 1
         ranges.push {start: token.start, end: token.end}
-    {correct: ranges}
+    {id, correct: ranges}
 
   suggest: (args, word) ->
     @spelling.suggest word

--- a/lib/locale-checker.coffee
+++ b/lib/locale-checker.coffee
@@ -1,0 +1,129 @@
+spellchecker = require 'spellchecker'
+pathspec = require 'atom-pathspec'
+env = require './checker-env'
+
+# The locale checker is a checker that takes a locale string (`en-US`) and
+# optionally a path and then checks it.
+class LocaleChecker
+  spellchecker: null
+  locale: null
+  enabled: true
+  reason: null
+  paths: null
+
+  constructor: (locale, paths) ->
+    @locale = locale
+    @paths = paths
+    @enabled = true
+    #console.log @getId(), "enabled", @isEnabled()
+
+  deactivate: ->
+    return
+
+  getId: -> "spell-check:locale:" + @locale.toLowerCase().replace("_", "-")
+  getName: -> "Locale Dictionary (" + @locale + ")"
+  getPriority: -> 100 # Hard-coded system level data, has no user input.
+  isEnabled: -> @enabled
+  getStatus: -> @reason
+  providesSpelling: (args) -> @enabled
+  providesSuggestions: (args) -> @enabled
+  providesAdding: (args) -> false
+
+  check: (args, text) ->
+    @deferredInit()
+    id = @getId()
+    if @enabled
+      @spellchecker.checkSpellingAsync(text).then (incorrect) ->
+        {id, invertIncorrectAsCorrect: true, incorrect}
+    else
+      {id, status: @getStatus()}
+
+  suggest: (args, word) ->
+    @deferredInit()
+    @spellchecker.getCorrectionsForMisspelling(word)
+
+  deferredInit: ->
+    # The system checker is not enabled for Linux platforms (no built-in checker).
+    if not @enabled
+      @reason = "Darwin does not use locale-based checking without SPELLCHECKER_PREFER_HUNSPELL set."
+      return
+
+    # If we already have a spellchecker, then we don't have to do anything.
+    if @spellchecker
+      return
+
+    # Initialize the spell checker which can take some time. We also force
+    # the use of the Hunspell library even on Mac OS X. The "system checker"
+    # is the one that uses the built-in dictionaries from the operating system.
+    @spellchecker = new spellchecker.Spellchecker
+    @spellchecker.setSpellcheckerType spellchecker.ALWAYS_USE_HUNSPELL
+
+    # Build up a list of paths we are checking so we can report them fully
+    # to the user if we fail.
+    searchPaths = []
+
+    # Windows uses its own API and the paths are unimportant, only attempting
+    # to load it works.
+    if env.isWindows()
+      #if env.useWindowsSystemDictionary()
+      #  return
+      searchPaths.push "C:\\"
+
+    # Check the paths supplied by the user.
+    for path in @paths
+      searchPaths.push pathspec.getPath(path)
+
+    # For Linux, we have to search the directory paths to find the dictionary.
+    if env.isLinux()
+      searchPaths.push "/usr/share/hunspell"
+      searchPaths.push "/usr/share/myspell"
+      searchPaths.push "/usr/share/myspell/dicts"
+
+    # OS X uses the following paths.
+    if env.isDarwin()
+      searchPaths.push "/"
+      searchPaths.push "/System/Library/Spelling"
+
+    # Try the packaged library inside the node_modules. `getDictionaryPath` is
+    # not available, so we have to fake it. This will only work for en-US.
+    searchPaths.push spellchecker.getDictionaryPath()
+
+    # Attempt to load all the paths for the dictionary until we find one.
+    for path in searchPaths
+      if @spellchecker.setDictionary @locale, path
+        return
+
+    # If we fell through all the if blocks, then we couldn't load the dictionary.
+    @enabled = false
+    @reason = "Cannot load the system dictionary for `" + @locale + "`."
+    message = "The package `spell-check` cannot load the " \
+      + "checker for `" \
+      + @locale + "`." \
+      + " See the settings for ways of changing the languages used, " \
+      + " resolving missing dictionaries, or hiding this warning."
+
+    searches = "\n\nThe plugin checked the following paths for dictionary files:\n* " \
+      + searchPaths.join("\n* ")
+
+    if not env.useLocales()
+      searches = "\n\nThe plugin tried to use the system dictionaries to find the locale."
+
+    noticesMode = atom.config.get('spell-check.noticesMode')
+
+    if noticesMode is "console" or noticesMode is "both"
+      console.log @getId(), (message + searches)
+    if noticesMode is "popup" or noticesMode is "both"
+      atom.notifications.addWarning(
+        message,
+        {
+          buttons: [
+            {
+              className: "btn",
+              onDidClick: -> atom.workspace.open("atom://config/packages/spell-check"),
+              text: "Settings"
+            }
+          ]
+        }
+      )
+
+module.exports = LocaleChecker

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,6 +16,7 @@ module.exports =
       # These are the settings that are part of the main `spell-check` package.
       locales: atom.config.get('spell-check.locales'),
       localePaths: atom.config.get('spell-check.localePaths'),
+      useSystem: atom.config.get('spell-check.useSystem'),
       useLocales: atom.config.get('spell-check.useLocales'),
       knownWords: atom.config.get('spell-check.knownWords'),
       addKnownWords: atom.config.get('spell-check.addKnownWords'),
@@ -41,6 +42,9 @@ module.exports =
       manager.setGlobalArgs @globalArgs
     @subs.add atom.config.onDidChange 'spell-check.localePaths', ({newValue, oldValue}) =>
       @globalArgs.localePaths = newValue
+      manager.setGlobalArgs @globalArgs
+    @subs.add atom.config.onDidChange 'spell-check.useSystem', ({newValue, oldValue}) =>
+      @globalArgs.useSystem = newValue
       manager.setGlobalArgs @globalArgs
     @subs.add atom.config.onDidChange 'spell-check.useLocales', ({newValue, oldValue}) =>
       @globalArgs.useLocales = newValue

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "atom-select-list": "^0.7.0",
     "multi-integer-range": "^2.0.0",
     "natural": "^0.4.0",
-    "spellchecker": "^3.6.0",
+    "spellchecker": "^3.7.0",
     "spelling-manager": "^1.1.0",
     "underscore-plus": "^1"
   },
@@ -41,11 +41,17 @@
       "description": "List of sub-scopes that will be ignored. Specify the most detailed scope to avoid ignoring otherwise relevant text. The scopes will be parsed as regular expressions. See [the README](https://github.com/atom/spell-check#spell-check-package-) for more information on finding the correct scope for a specific language.",
       "order": 2
     },
+    "useSystem": {
+      "type": "boolean",
+      "default": true,
+      "description": "If checked, use the built-in spell checking on macOS and some versions of Windows. This setting is ignored on Linux, even if checked.",
+      "order": 3
+    },
     "useLocales": {
       "type": "boolean",
-      "default": "true",
-      "description": "If unchecked, then the locales below will not be used for spell-checking and no spell-checking using system dictionaries will be provided.",
-      "order": 3
+      "default": true,
+      "description": "If checked, then the locales below will be used to check words using Hunspell.",
+      "order": 4
     },
     "locales": {
       "type": "array",
@@ -53,8 +59,8 @@
       "items": {
         "type": "string"
       },
-      "description": "List of locales to use for the system spell-checking. Examples would be `en-US` or `de-DE`. For Windows, the appropriate language must be installed using *Region and language settings*. If this is blank, then the default language for the user will be used.",
-      "order": 4
+      "description": "List of locales to use for the system spell-checking. Examples would be `en-US` or `de-DE`. If this is blank, then the default language for the user will be used.",
+      "order": 5
     },
     "localePaths": {
       "type": "array",
@@ -62,26 +68,26 @@
       "items": {
         "type": "string"
       },
-      "description": "List of additional paths to search for dictionary files. If a locale cannot be found in these, the internal code will attempt to find it using common search paths. This is used for Linux and OS X.",
-      "order": 5
+      "description": "List of additional paths to search for dictionary files when checking using locales. If a locale cannot be found in these, the internal code will attempt to find it using common search paths.",
+      "order": 6
     },
     "knownWords": {
       "type": "array",
       "default": [],
       "description": "List words that are considered correct even if they do not appear in any other dictionary. Words with capitals or ones that start with `!` are case-sensitive.",
-      "order": 6
+      "order": 7
     },
     "addKnownWords": {
       "type": "boolean",
       "default": false,
       "description": "If checked, then the suggestions will include options to add to the known words list above.",
-      "order": 7
+      "order": 8
     },
     "noticesMode": {
       "type": "string",
       "default": "both",
       "description": "Choose where loading errors and other notices are displayed: popup, console, or both.",
-      "order": 8,
+      "order": 9,
       "enum": [
         {
           "value": "both",


### PR DESCRIPTION
### Requirements

While investigating https://github.com/atom/atom/issues/15912, the problem seemed to be based on calling the macOS built-in checking library with different locales. With multiple languages, that would call it with first one and then the second. Eventually, there would be an error thrown that caused the system to crash.

Then, while working on that item, we identified a problem where certain Windows 10 installations (in my case, an enterprise-distributed one) don't always provide spell-checking for non-English dictionaries and therefore couldn't use the built-in language for non-English (or whatever) languages.

In both of these cases, we need to be able to use system checker in a generic manner (without specifying language) or force the use of Hunspell even without the environment variable.

### Description of the Change

So, to fix that, I got https://github.com/atom/node-spellchecker/pull/115 merged that exposes an explicit flag to choose system or Hunspell-based checking while setting up the library.

Now, I need to change the UI to split built-in system checking verses locale which involves some UI changes and verification since now there are more options to control how spell-checking is done.

The three environments also have different rules:

1. Linux does not provide system checking, so it is ignored.
2. macOS and Windows can't take languages for the system checking.
3. All three need to handle specified locale checking.

### Alternate Designs

Originally this was going to just be a macOS fix however the validation with Windows 10 that caused the problem identified a more generic problem.

I also considered splitting out the `spell-check` checkers out into `spell-check-windows`, `spell-check-macos`, `spell-check-hunspell` but I [didn't get a definitive opinion](https://github.com/atom/spell-check/issues/154) either way. This option is still possible, it would just require automatically packaging 1-3 of these with the normal Atom installation.

### Benefits

1. It won't crash on macOS. (https://github.com/atom/atom/issues/15912)
2. It should handle the Windows installations that can't check other languages.

### Possible Drawbacks

1. Increased complexity to the settings.
2. Possibly slower performance if Hunspell and system are enabled.

### Applicable Issues

- https://github.com/atom/atom/issues/15912
- https://github.com/atom/spell-check/issues/154