### PR TITLE
Fix issues with Windows and Mac checking, reduce noise

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -1,0 +1,15 @@
+Here are additional details for debugging for working with the library.
+
+## Plugins
+
+_Spell Check_ allows for plugins to provide additional spell checking functionality. See the `PLUGINS.md` file in the repository on how to write a plugin.
+
+## Debugging
+
+Debugging messages for this library can be enabled by going into the developer console and running the following:
+
+```
+localStorage.debug = 'spell-check:*'
+```
+
+A reload of the window may be required.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To get the search paths used to look for a dictionary, make sure the "Notices Mo
 
 #### Hunspell Dictionaries
 
-For all platforms, a Hunspell-compatible dictionary is supported. To use this, a `.dic` and `.aff` need to be located in one of the default search directories or in a directory entered into "Locale paths" (multiples may be entered with commas separating them). If the appropriate files are found for the locale and "Use Locales" is checked, then the dictionary will be used.
+For all platforms, a Hunspell-compatible dictionary is also supported. To use this, a `.dic` and `.aff` need to be located in one of the default search directories or in a directory entered into "Locale paths" (multiples may be entered with commas separating them). If the appropriate files are found for the locale and "Use Locales" is checked, then the dictionary will be used.
 
 For example, if the following is set, then `/usr/share/hunspell/en_US.dic` will be used:
 
@@ -83,7 +83,9 @@ Once the additional language is added, Atom will need to be restarted.
 
 *Previously, setting `SPELLCHECKER_PREFER_HUNSPELL` environment variable would change how checking works. Now this is controlled by the system and locale checker to use the operating system version or Hunspell respectively.*
 
-If locale is not set, Atom will attempt to use the current locale from the environment variable; if that is missing, `en-US` will be used. The dictionary for `en-US` is shipping with Atom but all other locale-based dictionaries will need to be downloaded from another source.
+If locale is not set, Atom will attempt to use the current locale from the environment variable and use the Windows checking if available; if that is missing, `en-US` will be used. The dictionary for `en-US` is shipping with Atom but all other locale-based dictionaries will need to be downloaded from another source.
+
+If a Hunspell dictionary is found on a path, it will be used in favor of the Windows API.
 
 ### Debian, Ubuntu, and Mint
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ If "Use Locales" is set, those dictionaries will always be based on individual `
 
 You can use "Use System" and "Use Locales" at the same time.
 
+## Windows
+
+On Windows, "Use Locales" is needed to use the built-in Windows Spelling API because you can enable or disable checking based on desired language.
+
 ## Changing the dictionary
 
 To change the language of the dictionary, set the "Locales" configuration option to the IETF tag (en-US, fr-FR, etc). More than one language can be used, simply separate them by commas.

--- a/README.md
+++ b/README.md
@@ -18,21 +18,13 @@ You can override this from the _Spell Check_ settings in the Settings View (<kbd
 To enable _Spell Check_ for your current file type: put your cursor in the file, open the [Command Palette](https://github.com/atom/command-palette)
 (<kbd>cmd-shift-p</kbd>), and run the `Editor: Log Cursor Scope` command. This will trigger a notification which will contain a list of scopes. The first scope that's listed is the one you should add to the list of scopes in the settings for the _Spell Check_ package. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.
 
-## Mac
-
-On the Mac, in most cases checking "Use System" and clearing the check on "Use Locales" will be the most appropriate. The Mac's dictionary library uses all of the user's loaded dictionaries and doesn't require any customization within Atom.
-
-If "Use Locales" is set, those dictionaries will always be based on individual `.dic` files.
-
-You can use "Use System" and "Use Locales" at the same time.
-
-## Windows
-
-On Windows, "Use Locales" is needed to use the built-in Windows Spelling API because you can enable or disable checking based on desired language.
-
 ## Changing the dictionary
 
-To change the language of the dictionary, set the "Locales" configuration option to the IETF tag (en-US, fr-FR, etc). More than one language can be used, simply separate them by commas.
+Except for Mac, Atom needs to know what language to use to perform spell-checking. To list these, set the "Locales" configuration option to the IETF tag (en-US, fr-FR, etc). More than one language can be used, simply separate them by commas.
+
+If no locale is given, then Atom will attempt to infer the language based on environment variables and settings.
+
+If any value is given for the "Locales", then Atom will not automatically add the browser language. So, if your browser is United States English (`en-US`), leaving this blank will still do US English checking. However, if it the "Locales" is set to French (`fr-FR`), then the checker will only check French. If the "Locales" is set to `en-US, fr-FR`, then both languages will be checked.
 
 ### Missing Languages
 
@@ -40,34 +32,13 @@ This plugin uses the existing system dictionaries. If a locale is selected that 
 
 To get the search paths used to look for a dictionary, make sure the "Notices Mode" is set to "console" or "both", then reload Atom. The developer's console will have the directory list.
 
-#### Hunspell Dictionaries
+## Mac
 
-For all platforms, a Hunspell-compatible dictionary is also supported. To use this, a `.dic` and `.aff` need to be located in one of the default search directories or in a directory entered into "Locale paths" (multiples may be entered with commas separating them). If the appropriate files are found for the locale and "Use Locales" is checked, then the dictionary will be used.
+On the Mac, checking "Use System" will use the operating system's spellchecking library. This uses all of the user's loaded dictionaries and doesn't require any customization within Atom.
 
-For example, if the following is set, then `/usr/share/hunspell/en_US.dic` will be used:
+Checking "Use Locales" and providing locales would use Hunspell as additional dictionaries. Having "Use Locales" checked but no locales given will do nothing.
 
-- Use Locales: checked
-- Locales: `en-US`
-- Locale Paths: `/usr/share/hunspell`
-
-If "Locales" is not provided, then the user's current language will be inferred from environmental settings.
-
-In addition to what is provided, the following paths are checked:
-
-- `/usr/share/hunspell` (Linux only)
-- `/usr/share/myspell` (Linux only)
-- `/usr/share/myspell/dicts` (Linux only)
-- `/` (Mac only)
-- `/System/Library/Spelling` (Mac only)
-- `C:\` (Windows only)
-
-On Windows, the Windows spell checker will also be checked (see below) based on the locale paths.
-
-Dictionaries can be downloaded from various sites (such as [wooorm's repository](https://github.com/wooorm/dictionaries) or [LibreOffice's](https://github.com/LibreOffice/dictionaries)), but the file has to be renamed `locale.dic` and `locale.aff`.
-
-*Example locations to download are not an endorsement.*
-
-#### Windows 8 and Higher
+## Windows 8 and Higher
 
 For Windows 8 and 10, this package uses the Windows spell checker, so you must install the language using the regional settings before the language can be chosen inside Atom.
 
@@ -79,13 +50,13 @@ If your Windows user does not have Administration privileges, you'll need to do 
 
 ![Download the "Basic Typing" language option](docs/windows-10-language-settings-3.png)
 
-Once the additional language is added, Atom will need to be restarted.
+Once the additional language is added, Atom will need to be restarted and configured to use it. Add the IEFT tag into the "Locales" setting for the language to be set.
 
-*Previously, setting `SPELLCHECKER_PREFER_HUNSPELL` environment variable would change how checking works. Now this is controlled by the system and locale checker to use the operating system version or Hunspell respectively.*
+If a Hunspell dictionary is found on a path (see below), it will be used in favor of the Windows API.
 
-If locale is not set, Atom will attempt to use the current locale from the environment variable and use the Windows checking if available; if that is missing, `en-US` will be used. The dictionary for `en-US` is shipping with Atom but all other locale-based dictionaries will need to be downloaded from another source.
+## Linux
 
-If a Hunspell dictionary is found on a path, it will be used in favor of the Windows API.
+For all Linux-based operating systems, "Use System" does nothing. It can remained checked but has no impact. "Use Locales" is required for spell-checking.
 
 ### Debian, Ubuntu, and Mint
 
@@ -127,16 +98,27 @@ sudo ln -s en_GB-large.dic en_GB.dic
 sudo ln -s en_GB-large.aff en_GB.aff
 ```
 
-## Plugins
+## Hunspell Dictionaries
 
-_Spell Check_ allows for plugins to provide additional spell checking functionality. See the `PLUGINS.md` file in the repository on how to write a plugin.
+For all platforms, a Hunspell-compatible dictionary is also supported. To use this, a `.dic` and `.aff` need to be located in one of the default search directories or in a directory entered into "Locale paths" (multiples may be entered with commas separating them). If the appropriate files are found for the locale and "Use Locales" is checked, then the dictionary will be used.
 
-## Debugging
+For example, if the following is set, then `/usr/share/hunspell/en_US.dic` will be used:
 
-Debugging messages for this library can be enabled by going into the developer console and running the following:
+- Use Locales: checked
+- Locales: `en-US`
+- Locale Paths: `/usr/share/hunspell`
 
-```
-localStorage.debug = 'spell-check:*'
-```
+If "Locales" is not provided, then the user's current language will be inferred from environmental settings.
 
-A reload of the window may be required.
+In addition to what is provided, the following paths are checked:
+
+- `/usr/share/hunspell` (Linux only)
+- `/usr/share/myspell` (Linux only)
+- `/usr/share/myspell/dicts` (Linux only)
+- `/` (Mac only)
+- `/System/Library/Spelling` (Mac only)
+- `C:\` (Windows only)
+
+Dictionaries can be downloaded from various sites (such as [wooorm's repository](https://github.com/wooorm/dictionaries) or [LibreOffice's](https://github.com/LibreOffice/dictionaries)), but the file has to be renamed `locale.dic` and `locale.aff`.
+
+*Example locations to download are not an endorsement.*

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ You can override this from the _Spell Check_ settings in the Settings View (<kbd
 To enable _Spell Check_ for your current file type: put your cursor in the file, open the [Command Palette](https://github.com/atom/command-palette)
 (<kbd>cmd-shift-p</kbd>), and run the `Editor: Log Cursor Scope` command. This will trigger a notification which will contain a list of scopes. The first scope that's listed is the one you should add to the list of scopes in the settings for the _Spell Check_ package. Here are some examples: `source.coffee`, `text.plain`, `text.html.basic`.
 
+## Mac
+
+On the Mac, in most cases checking "Use System" and clearing the check on "Use Locales" will be the most appropriate. The Mac's dictionary library uses all of the user's loaded dictionaries and doesn't require any customization within Atom.
+
+If "Use Locales" is set, those dictionaries will always be based on individual `.dic` files.
+
+You can use "Use System" and "Use Locales" at the same time.
+
 ## Changing the dictionary
 
 To change the language of the dictionary, set the "Locales" configuration option to the IETF tag (en-US, fr-FR, etc). More than one language can be used, simply separate them by commas.
@@ -27,6 +35,33 @@ To change the language of the dictionary, set the "Locales" configuration option
 This plugin uses the existing system dictionaries. If a locale is selected that is not installed, a warning will pop up when a document that would be spell-checked is loaded. To disable this, either remove the incorrect language from the "Locales" configuration or clear the check on "Use Locales" to disable it entirely.
 
 To get the search paths used to look for a dictionary, make sure the "Notices Mode" is set to "console" or "both", then reload Atom. The developer's console will have the directory list.
+
+#### Hunspell Dictionaries
+
+For all platforms, a Hunspell-compatible dictionary is supported. To use this, a `.dic` and `.aff` need to be located in one of the default search directories or in a directory entered into "Locale paths" (multiples may be entered with commas separating them). If the appropriate files are found for the locale and "Use Locales" is checked, then the dictionary will be used.
+
+For example, if the following is set, then `/usr/share/hunspell/en_US.dic` will be used:
+
+- Use Locales: checked
+- Locales: `en-US`
+- Locale Paths: `/usr/share/hunspell`
+
+If "Locales" is not provided, then the user's current language will be inferred from environmental settings.
+
+In addition to what is provided, the following paths are checked:
+
+- `/usr/share/hunspell` (Linux only)
+- `/usr/share/myspell` (Linux only)
+- `/usr/share/myspell/dicts` (Linux only)
+- `/` (Mac only)
+- `/System/Library/Spelling` (Mac only)
+- `C:\` (Windows only)
+
+On Windows, the Windows spell checker will also be checked (see below) based on the locale paths.
+
+Dictionaries can be downloaded from various sites (such as [wooorm's repository](https://github.com/wooorm/dictionaries) or [LibreOffice's](https://github.com/LibreOffice/dictionaries)), but the file has to be renamed `locale.dic` and `locale.aff`.
+
+*Example locations to download are not an endorsement.*
 
 #### Windows 8 and Higher
 
@@ -44,7 +79,7 @@ Once the additional language is added, Atom will need to be restarted.
 
 *Previously, setting `SPELLCHECKER_PREFER_HUNSPELL` environment variable would change how checking works. Now this is controlled by the system and locale checker to use the operating system version or Hunspell respectively.*
 
-If locale is not set, Atom will attempt to use the current locale from the environment variable; if that is missing, `en-US` will be used. The dictionary for `en-US` is shipping with Atom but all other locale-based checkers will need to be downloaded from another source.
+If locale is not set, Atom will attempt to use the current locale from the environment variable; if that is missing, `en-US` will be used. The dictionary for `en-US` is shipping with Atom but all other locale-based dictionaries will need to be downloaded from another source.
 
 ### Debian, Ubuntu, and Mint
 
@@ -89,3 +124,13 @@ sudo ln -s en_GB-large.aff en_GB.aff
 ## Plugins
 
 _Spell Check_ allows for plugins to provide additional spell checking functionality. See the `PLUGINS.md` file in the repository on how to write a plugin.
+
+## Debugging
+
+Debugging messages for this library can be enabled by going into the developer console and running the following:
+
+```
+localStorage.debug = 'spell-check:*'
+```
+
+A reload of the window may be required.

--- a/lib/locale-checker.coffee
+++ b/lib/locale-checker.coffee
@@ -39,7 +39,9 @@ class LocaleChecker
     @deferredInit()
     id = @getId()
     if @enabled
-      @spellchecker.checkSpellingAsync(text).then (incorrect) ->
+      @spellchecker.checkSpellingAsync(text).then (incorrect) =>
+        if @log.enabled
+          @log 'check', incorrect
         {id, invertIncorrectAsCorrect: true, incorrect}
     else
       {id, status: @getStatus()}

--- a/lib/locale-checker.coffee
+++ b/lib/locale-checker.coffee
@@ -1,6 +1,7 @@
 spellchecker = require 'spellchecker'
 pathspec = require 'atom-pathspec'
 env = require './checker-env'
+debug = require 'debug'
 
 # The locale checker is a checker that takes a locale string (`en-US`) and
 # optionally a path and then checks it.
@@ -13,11 +14,14 @@ class LocaleChecker
   checkDictionaryPath: true
   checkDefaultPaths: true
 
-  constructor: (locale, paths) ->
+  constructor: (locale, paths, hasSystemChecker, inferredLocale) ->
     @locale = locale
     @paths = paths
     @enabled = true
-    #console.log @getId(), "enabled", @isEnabled()
+    @hasSystemChecker = hasSystemChecker
+    @inferredLocale = inferredLocale
+    @log = debug('spell-check:locale-checker').extend(locale)
+    @log 'enabled', @isEnabled(), 'hasSystemChecker', @hasSystemChecker, 'inferredLocale', @inferredLocale
 
   deactivate: ->
     return
@@ -45,11 +49,6 @@ class LocaleChecker
     @spellchecker.getCorrectionsForMisspelling(word)
 
   deferredInit: ->
-    # The system checker is not enabled for Linux platforms (no built-in checker).
-    if not @enabled
-      @reason = "Darwin does not use locale-based checking without SPELLCHECKER_PREFER_HUNSPELL set."
-      return
-
     # If we already have a spellchecker, then we don't have to do anything.
     if @spellchecker
       return
@@ -57,48 +56,69 @@ class LocaleChecker
     # Initialize the spell checker which can take some time. We also force
     # the use of the Hunspell library even on Mac OS X. The "system checker"
     # is the one that uses the built-in dictionaries from the operating system.
-    @spellchecker = new spellchecker.Spellchecker
-    @spellchecker.setSpellcheckerType spellchecker.ALWAYS_USE_HUNSPELL
+    checker = new spellchecker.Spellchecker
+    checker.setSpellcheckerType spellchecker.ALWAYS_USE_HUNSPELL
 
     # Build up a list of paths we are checking so we can report them fully
     # to the user if we fail.
     searchPaths = []
-
-    # Windows uses its own API and the paths are unimportant, only attempting
-    # to load it works.
-    if @checkDefaultPaths and env.isWindows()
-      #if env.useWindowsSystemDictionary()
-      #  return
-      searchPaths.push "C:\\"
-
-    # Check the paths supplied by the user.
     for path in @paths
       searchPaths.push pathspec.getPath(path)
 
-    # For Linux, we have to search the directory paths to find the dictionary.
-    if @checkDefaultPaths and env.isLinux()
-      searchPaths.push "/usr/share/hunspell"
-      searchPaths.push "/usr/share/myspell"
-      searchPaths.push "/usr/share/myspell/dicts"
+    # Add operating system specific paths to the search list.
+    if @checkDefaultPaths
+      if env.isLinux()
+        searchPaths.push "/usr/share/hunspell"
+        searchPaths.push "/usr/share/myspell"
+        searchPaths.push "/usr/share/myspell/dicts"
 
-    # OS X uses the following paths.
-    if @checkDefaultPaths and env.isDarwin()
-      searchPaths.push "/"
-      searchPaths.push "/System/Library/Spelling"
+      if env.isDarwin()
+        searchPaths.push "/"
+        searchPaths.push "/System/Library/Spelling"
 
-    # Try the packaged library inside the node_modules. `getDictionaryPath` is
-    # not available, so we have to fake it. This will only work for en-US.
-    if @checkDictionaryPath
-      searchPaths.push spellchecker.getDictionaryPath()
+      if env.isWindows()
+        searchPaths.push "C:\\"
 
     # Attempt to load all the paths for the dictionary until we find one.
+    @log 'checking paths', searchPaths
     for path in searchPaths
-      if @spellchecker.setDictionary @locale, path
+      if checker.setDictionary @locale, path
+        @log 'found checker', path
+        @spellchecker = checker
         return
+
+    # On Windows, if we can't find the dictionary using the paths, then we also
+    # try the spelling API. This uses system checker with the given locale, but
+    # doesn't provide a path. We do this at the end to let Hunspell be used if
+    # the user provides that.
+    if env.isWindows()
+      systemChecker = new spellchecker.Spellchecker
+      systemChecker.setSpellcheckerType spellchecker.ALWAYS_USE_SYSTEM
+      if systemChecker.setDictionary @locale, ""
+          @log 'using Windows Spell API'
+          @spellchecker = systemChecker
+          return
+
+    # If all else fails, try the packaged en-US dictionary in the `spellcheck`
+    # library.
+    if @checkDictionaryPath
+      if checker.setDictionary @locale, spellchecker.getDictionaryPath()
+        @log 'using packaged locale', path
+        @spellchecker = checker
+        return
+
+    # If we are using the system checker and we infered the locale, then we
+    # don't want to show an error. This is because the system checker may have
+    # handled it already.
+    if @hasSystemChecker and @inferredLocale
+      @log 'giving up quietly because of system checker and inferred locale'
+      @enabled = false
+      @reason = "Cannot load the locale dictionary for `" + @locale + "`. No warning because system checker is in use and locale is inferred."
+      return
 
     # If we fell through all the if blocks, then we couldn't load the dictionary.
     @enabled = false
-    @reason = "Cannot load the system dictionary for `" + @locale + "`."
+    @reason = "Cannot load the locale dictionary for `" + @locale + "`."
     message = "The package `spell-check` cannot load the " \
       + "checker for `" \
       + @locale + "`." \

--- a/lib/locale-checker.coffee
+++ b/lib/locale-checker.coffee
@@ -10,6 +10,8 @@ class LocaleChecker
   enabled: true
   reason: null
   paths: null
+  checkDictionaryPath: true
+  checkDefaultPaths: true
 
   constructor: (locale, paths) ->
     @locale = locale
@@ -64,7 +66,7 @@ class LocaleChecker
 
     # Windows uses its own API and the paths are unimportant, only attempting
     # to load it works.
-    if env.isWindows()
+    if @checkDefaultPaths and env.isWindows()
       #if env.useWindowsSystemDictionary()
       #  return
       searchPaths.push "C:\\"
@@ -74,19 +76,20 @@ class LocaleChecker
       searchPaths.push pathspec.getPath(path)
 
     # For Linux, we have to search the directory paths to find the dictionary.
-    if env.isLinux()
+    if @checkDefaultPaths and env.isLinux()
       searchPaths.push "/usr/share/hunspell"
       searchPaths.push "/usr/share/myspell"
       searchPaths.push "/usr/share/myspell/dicts"
 
     # OS X uses the following paths.
-    if env.isDarwin()
+    if @checkDefaultPaths and env.isDarwin()
       searchPaths.push "/"
       searchPaths.push "/System/Library/Spelling"
 
     # Try the packaged library inside the node_modules. `getDictionaryPath` is
     # not available, so we have to fake it. This will only work for en-US.
-    searchPaths.push spellchecker.getDictionaryPath()
+    if @checkDictionaryPath
+      searchPaths.push spellchecker.getDictionaryPath()
 
     # Attempt to load all the paths for the dictionary until we find one.
     for path in searchPaths

--- a/lib/locale-checker.coffee
+++ b/lib/locale-checker.coffee
@@ -95,9 +95,9 @@ class LocaleChecker
       systemChecker = new spellchecker.Spellchecker
       systemChecker.setSpellcheckerType spellchecker.ALWAYS_USE_SYSTEM
       if systemChecker.setDictionary @locale, ""
-          @log 'using Windows Spell API'
-          @spellchecker = systemChecker
-          return
+        @log 'using Windows Spell API'
+        @spellchecker = systemChecker
+        return
 
     # If all else fails, try the packaged en-US dictionary in the `spellcheck`
     # library.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,4 +1,5 @@
 {CompositeDisposable} = require 'atom'
+debug = require 'debug'
 
 SpellCheckView = null
 spellCheckViews = {}
@@ -7,6 +8,9 @@ LARGE_FILE_SIZE = 2 * 1024 * 1024
 
 module.exports =
   activate: ->
+    log = debug('spell-check')
+    log('initializing')
+
     @subs = new CompositeDisposable
 
     # Since the spell-checking is done on another process, we gather up all the

--- a/lib/spell-check-manager.coffee
+++ b/lib/spell-check-manager.coffee
@@ -1,3 +1,5 @@
+env = require './checker-env'
+
 class SpellCheckerManager
   checkers: []
   checkerPaths: []
@@ -35,20 +37,22 @@ class SpellCheckerManager
       @removeSpellChecker @knownWordsChecker
       @knownWordsChecker = null
 
-    # Handle system checker.
+    # Handle system checker. We also will remove the locale checkers if we
+    # change the system checker because we show different messages if we cannot
+    # find a locale based on the use of the system checker.
     removeSystemChecker = false
+    removeLocaleCheckers = false
 
     if @useSystem isnt data.useSystem
       @useSystem = data.useSystem
       removeSystemChecker = true
+      removeLocaleCheckers = true
 
     if removeSystemChecker and @systemChecker
       @removeSpellChecker @systemChecker
       @systemChecker = undefined
 
     # Handle locale checkers.
-    removeLocaleCheckers = false
-
     if not _.isEqual(@locales, data.locales)
       # If the locales is blank, then we always create a default one. However,
       # any new data.locales will remain blank.
@@ -317,6 +321,7 @@ class SpellCheckerManager
 
   init: ->
     # Set up the system checker.
+    hasSystemChecker = @useSystem and env.isSystemSupported()
     if @useSystem and @systemChecker is null
       SystemChecker = require './system-checker'
       @systemChecker = new SystemChecker
@@ -335,10 +340,14 @@ class SpellCheckerManager
       @localeCheckers = []
 
       # If we have a blank location, use the default based on the process. If
-      # set, then it will be the best language.
+      # set, then it will be the best language. We keep track if we are using
+      # the default locale to control error messages.
+      inferredLocale = false
+
       if not @locales.length
         defaultLocale = process.env.LANG
         if defaultLocale
+          inferredLocale = true
           @locales = [defaultLocale.split('.')[0]]
 
       # If we can't figure out the language from the process, check the
@@ -351,18 +360,20 @@ class SpellCheckerManager
         if defaultLocale and defaultLocale.length is 5
           separatorChar = defaultLocale.charAt(2)
           if separatorChar is '_' or separatorChar is '-'
+            inferredLocale = true
             @locales = [defaultLocale]
 
       # If we still can't figure it out, use US English. It isn't a great
       # choice, but it is a reasonable default not to mention is can be used
       # with the fallback path of the `spellchecker` package.
       if not @locales.length
+        inferredLocale = true
         @locales = ['en_US']
 
       # Go through the new list and create new locale checkers.
       LocaleChecker = require "./locale-checker"
       for locale in @locales
-        checker = new LocaleChecker locale, @localePaths
+        checker = new LocaleChecker locale, @localePaths, hasSystemChecker, inferredLocale
         @addSpellChecker checker
         @localeCheckers.push checker
 

--- a/lib/spell-check-manager.coffee
+++ b/lib/spell-check-manager.coffee
@@ -153,6 +153,10 @@ class SpellCheckerManager
 
       # If we don't have any incorrect spellings, then there is nothing to worry
       # about, so just return and stop processing.
+      if @log.enabled
+        @log "merged correct ranges", correct
+        @log "merged incorrect ranges", incorrects
+
       if incorrects.length is 0
         @log "no spelling errors"
         return {misspellings: []}

--- a/lib/system-checker.coffee
+++ b/lib/system-checker.coffee
@@ -5,8 +5,14 @@ debug = require 'debug'
 
 # Initialize the global spell checker which can take some time. We also force
 # the use of the system or operating system library instead of Hunspell.
-instance = new spellchecker.Spellchecker
-instance.setSpellcheckerType spellchecker.ALWAYS_USE_SYSTEM
+if env.isSystemSupported()
+  instance = new spellchecker.Spellchecker
+  instance.setSpellcheckerType spellchecker.ALWAYS_USE_SYSTEM
+
+  if not instance.setDictionary("", "")
+    instance = undefined
+else
+  instance = undefined
 
 # The `SystemChecker` is a special case to use the built-in system spell-checking
 # provided by some platforms, such as Windows 8+ and macOS. This also doesn't have
@@ -24,12 +30,12 @@ class SystemChecker
   getId: -> "spell-check:system"
   getName: -> "System Checker"
   getPriority: -> 110
-  isEnabled: -> env.isSystemSupported()
+  isEnabled: -> instance
   getStatus: ->
-    if env.isSystemSupported()
+    if instance
       "working correctly"
     else
-      "disabled on Linux"
+      "not supported on platform"
 
   providesSpelling: (args) -> @isEnabled()
   providesSuggestions: (args) -> @isEnabled()

--- a/lib/system-checker.coffee
+++ b/lib/system-checker.coffee
@@ -1,6 +1,7 @@
 spellchecker = require 'spellchecker'
 pathspec = require 'atom-pathspec'
 env = require './checker-env'
+debug = require 'debug'
 
 # Initialize the global spell checker which can take some time. We also force
 # the use of the system or operating system library instead of Hunspell.
@@ -14,7 +15,8 @@ instance.setSpellcheckerType spellchecker.ALWAYS_USE_SYSTEM
 # due to some memory bug.
 class SystemChecker
   constructor: ->
-    #console.log @getId(), "enabled", @isEnabled()
+    @log = debug('spell-check:system-checker')
+    @log 'enabled', @isEnabled(), @getStatus()
 
   deactivate: ->
     return
@@ -25,9 +27,9 @@ class SystemChecker
   isEnabled: -> env.isSystemSupported()
   getStatus: ->
     if env.isSystemSupported()
-      "Working correctly"
+      "working correctly"
     else
-      "Disabled on Linux"
+      "disabled on Linux"
 
   providesSpelling: (args) -> @isEnabled()
   providesSuggestions: (args) -> @isEnabled()
@@ -35,10 +37,12 @@ class SystemChecker
 
   check: (args, text) ->
     id = @getId()
+
     if @isEnabled()
       # We use the default checker here and not the locale-specific one so it
       # will check all languages at the same time.
-      instance.checkSpellingAsync(text).then (incorrect) ->
+      instance.checkSpellingAsync(text).then (incorrect) =>
+        @log 'check', text, incorrect
         {id, invertIncorrectAsCorrect: true, incorrect}
     else
       {id, status: @getStatus()}

--- a/lib/system-checker.coffee
+++ b/lib/system-checker.coffee
@@ -42,7 +42,8 @@ class SystemChecker
       # We use the default checker here and not the locale-specific one so it
       # will check all languages at the same time.
       instance.checkSpellingAsync(text).then (incorrect) =>
-        @log 'check', text, incorrect
+        if @log.enabled
+          @log 'check', incorrect
         {id, invertIncorrectAsCorrect: true, incorrect}
     else
       {id, status: @getStatus()}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "atom-pathspec": "^0.0.0",
     "atom-select-list": "^0.7.0",
+    "debug": "^4.1.1",
     "multi-integer-range": "^2.0.0",
     "natural": "^0.4.0",
     "spellchecker": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "useLocales": {
       "type": "boolean",
       "default": true,
-      "description": "If checked, then the locales below will be used to check words using Hunspell.",
+      "description": "If checked, then the locales below will be used for checking.",
       "order": 4
     },
     "locales": {

--- a/spec/locale-checker-spec.js
+++ b/spec/locale-checker-spec.js
@@ -4,7 +4,7 @@ const {it, fit, ffit} = require('./async-spec-helpers')
 
 describe('Locale Checker', function () {
   it('can load en-US without paths', async function () {
-    checker = new LocaleChecker('en-US', [])
+    checker = new LocaleChecker('en-US', [], false, false)
     checker.deferredInit()
 
     expect(checker.isEnabled()).toEqual(true)
@@ -12,19 +12,28 @@ describe('Locale Checker', function () {
   })
 
   it('cannot load xx-XX without paths', async function () {
-    checker = new LocaleChecker('xx-XX', [])
+    checker = new LocaleChecker('xx-XX', [], false, false)
     checker.deferredInit()
 
     expect(checker.isEnabled()).toEqual(false)
     expect(checker.getStatus())
-      .toEqual('Cannot load the system dictionary for `xx-XX`.')
+      .toEqual('Cannot load the locale dictionary for `xx-XX`.')
+  })
+
+  it('cannot quietly load xx-XX without paths with system', async function () {
+    checker = new LocaleChecker('xx-XX', [], true, true)
+    checker.deferredInit()
+
+    expect(checker.isEnabled()).toEqual(false)
+    expect(checker.getStatus())
+      .toEqual('Cannot load the locale dictionary for `xx-XX`. No warning because system checker is in use and locale is inferred.')
   })
 
   // On Windows, not using the built-in path should use the
   // Spelling API.
   if (env.isWindows()) {
     it('can load en-US from Windows API', async function () {
-      checker = new LocaleChecker('en-US', [])
+      checker = new LocaleChecker('en-US', [], false, false)
       checker.checkDictionaryPath = false;
       checker.checkDefaultPaths = false;
       checker.deferredInit()
@@ -34,13 +43,13 @@ describe('Locale Checker', function () {
     })
   } else {
     it('cannot load en-US without paths or fallback', async function () {
-      checker = new LocaleChecker('en-US', [])
+      checker = new LocaleChecker('en-US', [], false, false)
       checker.checkDictionaryPath = false;
       checker.checkDefaultPaths = false;
       checker.deferredInit()
 
       expect(checker.isEnabled()).toEqual(false)
-      expect(checker.getStatus()).toEqual('Cannot load the system dictionary for `en-US`.')
+      expect(checker.getStatus()).toEqual('Cannot load the locale dictionary for `en-US`.')
     })
   }
 })

--- a/spec/locale-checker-spec.js
+++ b/spec/locale-checker-spec.js
@@ -1,0 +1,46 @@
+const LocaleChecker = require('../lib/locale-checker')
+const env = require('../lib/checker-env')
+const {it, fit, ffit} = require('./async-spec-helpers')
+
+describe('Locale Checker', function () {
+  it('can load en-US without paths', async function () {
+    checker = new LocaleChecker('en-US', [])
+    checker.deferredInit()
+
+    expect(checker.isEnabled()).toEqual(true)
+    expect(checker.getStatus()).toEqual(null)
+  })
+
+  it('cannot load xx-XX without paths', async function () {
+    checker = new LocaleChecker('xx-XX', [])
+    checker.deferredInit()
+
+    expect(checker.isEnabled()).toEqual(false)
+    expect(checker.getStatus())
+      .toEqual('Cannot load the system dictionary for `xx-XX`.')
+  })
+
+  // On Windows, not using the built-in path should use the
+  // Spelling API.
+  if (env.isWindows()) {
+    it('can load en-US from Windows API', async function () {
+      checker = new LocaleChecker('en-US', [])
+      checker.checkDictionaryPath = false;
+      checker.checkDefaultPaths = false;
+      checker.deferredInit()
+
+      expect(checker.isEnabled()).toEqual(true)
+      expect(checker.getStatus()).toEqual(null)
+    })
+  } else {
+    it('cannot load en-US without paths or fallback', async function () {
+      checker = new LocaleChecker('en-US', [])
+      checker.checkDictionaryPath = false;
+      checker.checkDefaultPaths = false;
+      checker.deferredInit()
+
+      expect(checker.isEnabled()).toEqual(false)
+      expect(checker.getStatus()).toEqual('Cannot load the system dictionary for `en-US`.')
+    })
+  }
+})


### PR DESCRIPTION
### Description of the Change

The recent changes to split system and locale checkers have caused some trouble with Windows Spell Checking and spurious warnings on Mac. This is to resolve them as described in https://github.com/atom/spell-check/issues/328. In specific:

- Windows with the default settings of "Use System" and "Use Locale" does not work with the default language.
- Mac with the default settings shows a warning though system checking is working correctly.

Many of these issues also show up when the default locale is *not* `en-US`.

### Alternate Designs

The main difficulty is coordinating the various rules that have to be applied:

- Mac *cannot* define locales or paths for system checking to avoid process crashes.
- Windows *must* define locales but *cannot* provide a path to use Spelling API.
- Linux must use locales. System checking does nothing.
- All can define a locale and path to use Hunspell.

The resulting fix was basically to smooth over some of the issues with these various conditions.

### Benefits

This will benefit most users who want spelling to work in these conditions and not see warnings without unchecking "Use Locales".

I also noticed that there was some confusion on how to set up dictionaries and attempted to clarify the instructions to include more details in the `README.md`.

### Possible Drawbacks

There are a lot of situations where one thing works and another doesn't. Someone may expect to see a warning that won't, but folks should not see more warnings.

Also, Dylan is unable to test on Windows or Mac, so extra care or verification would be greatly appreciated on those platforms.

### Applicable Issues

- https://github.com/atom/spell-check/issues/328
