### PR TITLE
Add enableDebug to config

### DIFF
--- a/lib/locale-checker.js
+++ b/lib/locale-checker.js
@@ -21,7 +21,7 @@ class LocaleChecker {
         this.enabled = true;
         this.hasSystemChecker = hasSystemChecker;
         this.inferredLocale = inferredLocale;
-        if (atom.config.get("spell-check.enableDebug")) {
+        if (atom.config.get('spell-check.enableDebug')) {
             debug = require('debug');
             this.log = debug('spell-check:locale-checker').extend(locale);
         } else {

--- a/lib/locale-checker.js
+++ b/lib/locale-checker.js
@@ -1,7 +1,6 @@
 const spellchecker = require('spellchecker');
 const pathspec = require('atom-pathspec');
 const env = require('./checker-env');
-const debug = require('debug');
 
 // The locale checker is a checker that takes a locale string (`en-US`) and
 // optionally a path and then checks it.
@@ -22,7 +21,12 @@ class LocaleChecker {
         this.enabled = true;
         this.hasSystemChecker = hasSystemChecker;
         this.inferredLocale = inferredLocale;
-        this.log = debug('spell-check:locale-checker').extend(locale);
+        if (atom.config.get("spell-check.enableDebug")) {
+            debug = require('debug');
+            this.log = debug('spell-check:locale-checker').extend(locale);
+        } else {
+            this.log = console.log
+        }
         this.log(
             'enabled',
             this.isEnabled(),

--- a/lib/locale-checker.js
+++ b/lib/locale-checker.js
@@ -25,7 +25,7 @@ class LocaleChecker {
             debug = require('debug');
             this.log = debug('spell-check:locale-checker').extend(locale);
         } else {
-            this.log = console.log
+            this.log = (str) => {};
         }
         this.log(
             'enabled',

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,7 @@ let log = (str) => {};
 
 module.exports = {
     activate() {
-        if (atom.config.get("spell-check.enableDebug")) {
+        if (atom.config.get('spell-check.enableDebug')) {
             debug = require('debug');
             log = debug('spell-check');
         }

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,7 +5,7 @@ let spellCheckViews = {};
 
 const LARGE_FILE_SIZE = 2 * 1024 * 1024;
 
-let log = console.log
+let log = (str) => {};
 
 module.exports = {
     activate() {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,14 +1,19 @@
 const { CompositeDisposable } = require('atom');
-const debug = require('debug');
 
 let SpellCheckView = null;
 let spellCheckViews = {};
 
 const LARGE_FILE_SIZE = 2 * 1024 * 1024;
 
+let log = console.log
+
 module.exports = {
     activate() {
-        const log = debug('spell-check');
+        if (atom.config.get("spell-check.enableDebug")) {
+            debug = require('debug');
+            log = debug('spell-check');
+        }
+
         log('initializing');
 
         this.subs = new CompositeDisposable();

--- a/lib/spell-check-manager.js
+++ b/lib/spell-check-manager.js
@@ -1,4 +1,3 @@
-const debug = require('debug');
 const env = require('./checker-env');
 
 class SpellCheckerManager {
@@ -424,7 +423,12 @@ class SpellCheckerManager {
 
     init() {
         // Set up logging.
-        this.log = debug('spell-check:spell-check-manager');
+        if (atom.config.get("spell-check.enableDebug")) {
+            debug = require('debug');
+            this.log = debug('spell-check:spell-check-manager');
+        } else {
+            this.log = console.log
+        }
 
         // Set up the system checker.
         const hasSystemChecker = this.useSystem && env.isSystemSupported();

--- a/lib/spell-check-manager.js
+++ b/lib/spell-check-manager.js
@@ -427,7 +427,7 @@ class SpellCheckerManager {
             debug = require('debug');
             this.log = debug('spell-check:spell-check-manager');
         } else {
-            this.log = console.log
+            this.log = (str) => {};
         }
 
         // Set up the system checker.

--- a/lib/spell-check-manager.js
+++ b/lib/spell-check-manager.js
@@ -423,7 +423,7 @@ class SpellCheckerManager {
 
     init() {
         // Set up logging.
-        if (atom.config.get("spell-check.enableDebug")) {
+        if (atom.config.get('spell-check.enableDebug')) {
             debug = require('debug');
             this.log = debug('spell-check:spell-check-manager');
         } else {

--- a/lib/system-checker.js
+++ b/lib/system-checker.js
@@ -2,7 +2,6 @@ let instance;
 const spellchecker = require('spellchecker');
 const pathspec = require('atom-pathspec');
 const env = require('./checker-env');
-const debug = require('debug');
 
 // Initialize the global spell checker which can take some time. We also force
 // the use of the system or operating system library instead of Hunspell.
@@ -24,7 +23,12 @@ if (env.isSystemSupported()) {
 // due to some memory bug.
 class SystemChecker {
     constructor() {
-        this.log = debug('spell-check:system-checker');
+        if (atom.config.get("spell-check.enableDebug")) {
+            debug = require('debug');
+            this.log = debug('spell-check:system-checker');
+        } else {
+            this.log = console.log
+        }
         this.log('enabled', this.isEnabled(), this.getStatus());
     }
 

--- a/lib/system-checker.js
+++ b/lib/system-checker.js
@@ -23,7 +23,7 @@ if (env.isSystemSupported()) {
 // due to some memory bug.
 class SystemChecker {
     constructor() {
-        if (atom.config.get("spell-check.enableDebug")) {
+        if (atom.config.get('spell-check.enableDebug')) {
             debug = require('debug');
             this.log = debug('spell-check:system-checker');
         } else {

--- a/lib/system-checker.js
+++ b/lib/system-checker.js
@@ -27,7 +27,7 @@ class SystemChecker {
             debug = require('debug');
             this.log = debug('spell-check:system-checker');
         } else {
-            this.log = console.log
+            this.log = (str) => {};
         }
         this.log('enabled', this.isEnabled(), this.getStatus());
     }

--- a/package.json
+++ b/package.json
@@ -110,6 +110,12 @@
           "description": "Display notices only on the console"
         }
       ]
+    },
+    "enableDebug": {
+      "type": "boolean",
+      "default": false,
+      "title": "Enable debug information for spell check",
+      "order": 10
     }
   },
   "consumedServices": {


### PR DESCRIPTION
### Description of the Change

- Makes debug loading lazy and hides it behind a setting. This is inline with Atom's snapshot system
- This adds a config which allows to enable or disable debug


### Alternate Designs

### Benefits
- Allows spell-check to be included in the snapshot -> Unblocks https://github.com/atom/atom/pull/21777
- Adding UI for debugging makes it easier for normal users to enable/disable debugging.
- No extra overhead because of debug package. 
- Loading time is decreased from 29ms to 15ms

### Possible Drawbacks
N/A

### Applicable Issues

Fixes #356