### PR TITLE
Fixes unable to load package

### DIFF
--- a/lib/spell-check-task.js
+++ b/lib/spell-check-task.js
@@ -96,6 +96,8 @@ module.exports = SpellCheckTask = (function () {
 
         static startNextJob() {
             const activeEditor = atom.workspace.getActiveTextEditor();
+            if (!activeEditor) return;
+
             const activeEditorId = activeEditor.id;
             const job =
                 this.jobs.find((j) => j.editorId === activeEditorId) ||


### PR DESCRIPTION
This fixes the errors thrown by `language-todo` and `language-hyperlink`
![image](https://user-images.githubusercontent.com/15386677/109506625-b6571780-7a52-11eb-85b0-83f58ffb5a8b.png)
